### PR TITLE
Simpler actions interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ const reducer = combineReducers({
 const store = createStore(reducer);
 
 store.dispatch(counter.actions.increment());
-// -> { counter: 1, user: {} }
+// -> { counter: 1, user: { name: '' } }
 store.dispatch(counter.actions.increment());
-// -> { counter: 1, user: {} }
+// -> { counter: 2, user: { name: '' } }
 store.dispatch(counter.actions.multiply(3));
-// -> { counter: 6, user: {} }
+// -> { counter: 6, user: { name: '' } }
 console.log(`${counter.actions.decrement}`);
 // -> counter/decrement
 store.dispatch(user.actions.setUserName('eric'));
@@ -108,7 +108,7 @@ console.log(counter.selectors.getCounter(state));
 slice passed to the state, then this will assume that this is the entire state shape.
 
 `Actions` helps improve autocompelete and typing for the `actions` object returned from `robodux`.
-Supply an interface where they keys are the action names and the values are the functions that return actions.
+Supply an interface where they keys are the action names and the values are the payload types, which should be null if the action takes no payload.
 
 `State` is the entire state shape for when a slice is used with `robodux`.  This helps type the selectors we
 return which requires the entire state as the parameter and not simply the slice state.
@@ -128,8 +128,8 @@ interface State {
 }
 
 interface Actions {
-  set: (payload: SliceState) => Action;
-  reset: () => Action;
+  set: SliceState;
+  reset: null;
 }
 
 const defaultState = {
@@ -146,9 +146,10 @@ const { actions, selectors, reducer } = robodux<SliceState, Actions, State>({
   initialState: defaultState,
 });
 
-const val = selectors.getHi({ hi: defaultState, other: true }); // assumes param is State
-actions.set({ test: 'ok', wow: 0 }); // autocomplete and type helping for payload
-actions.reset();
+const val = selectors.getHi({ hi: defaultState, other: true }); // typechecks param as State
+actions.set({ test: 'ok', wow: 0 }); // autocomplete and type checking for payload, typeerror if called without payload
+actions.reset(); // typechecks to ensure action is called without params
+
 ```
 
 ## Slice Helpers
@@ -234,6 +235,11 @@ console.log(increment);
 // -> 'INCREMENT'
 console.log(increment(2));
 // { type: 'INCREMENT', payload: 2 };
+const storeDetails = createAction('STORE_DETAILS');
+console.log(storeDetails);
+// -> 'STORE_DETAILS'
+console.log(storeDetails({name: 'John', surname: 'Doe'}));
+// { type: 'INCREMENT', payload: {name: 'John', surname: 'Doe'} };
 ```
 
 ### createReducer

--- a/examples/types.ts
+++ b/examples/types.ts
@@ -1,5 +1,5 @@
 import robodux from '../src/slice';
-import { Action } from 'redux';
+import { Action, combineReducers, createStore } from 'redux';
 
 interface SliceState {
   test: string;
@@ -24,7 +24,7 @@ const defaultState = {
 const { actions, selectors, reducer } = robodux<SliceState, Actions, State>({
   slice: 'hi',
   actions: {
-    set: (state: SliceState, payload: SliceState) => payload,
+    set: (state, payload) => payload,
     reset: () => defaultState,
   },
   initialState: defaultState,
@@ -34,3 +34,140 @@ const val = selectors.getHi({ hi: defaultState, other: true });
 actions.set({ test: 'ok', wow: 0 });
 actions.reset();
 const red = reducer;
+
+console.log(val, red);
+
+interface ISliceState {
+  idToken: string;
+  userId: string;
+  authenticating: boolean;
+  error: Error;
+}
+
+interface AuthActions {
+  authSuccess: (payload: { idToken: string; userId: string }) => Action;
+  authStart: () => Action;
+  authFail: (error: Error) => Action;
+  authLogout: () => Action;
+}
+
+interface IState {
+  auth: ISliceState;
+}
+
+const initialState: ISliceState = {
+  idToken: '',
+  userId: '',
+  authenticating: false,
+  error: null,
+};
+
+const auth = robodux<ISliceState, AuthActions, IState>({
+  slice: 'auth',
+  actions: {
+    authFail: (state, error) => {
+      state.error = error;
+      state.authenticating = false;
+    },
+    authLogout: (state) => {
+      state.idToken = null;
+      state.userId = null;
+    },
+    authStart: (state) => {
+      state.authenticating = true;
+    },
+    authSuccess: (state, payload) => {
+      state.idToken = payload.idToken;
+      state.userId = payload.userId;
+    },
+  },
+  initialState,
+});
+export const {
+  reducer: authReducer,
+  slice: authSlice,
+  actions: { authFail, authStart, authSuccess, authLogout },
+  selectors: { getAuth },
+} = auth;
+
+const rootReducer = combineReducers({
+  hi: reducer,
+  auth: authReducer,
+});
+
+const store = createStore(rootReducer);
+
+console.log('[auth object]', auth);
+/* 
+[auth object]
+ { 
+   actions: { 
+     authFail: { [Function: action] toString: [Function] },
+     authLogout: { [Function: action] toString: [Function] },
+     authStart: { [Function: action] toString: [Function] },
+     authSuccess: { [Function: action] toString: [Function] } 
+    },
+  reducer: { [Function: reducer] toString: [Function] },
+  slice: 'auth',
+  selectors: { getAuth: [Function] }
+ }
+ */
+console.log(authLogout());
+// [authLogout action creator]
+/* 
+{ type: 'auth/authLogout', payload: undefined }
+*/
+console.log(
+  authSuccess({ idToken: 'really Long Token', userId: 'Its Me' }),
+);
+/* 
+[authSuccess actionCreator] 
+{ 
+  type: 'auth/authSuccess',
+  payload: { idToken: 'really Long Token', userId: 'Its Me' } 
+} 
+  */
+console.log(authStart());
+// [authStart action creator]
+/* 
+{ type: 'auth/authStart', payload: undefined }
+*/
+
+console.log(
+  store.dispatch(authStart()),
+  getAuth(store.getState()),
+);
+// '[auth reducer called with undefined state and authStart action]'
+/* 
+Action: { type: 'auth/authStart', payload: undefined }
+
+New Auth State: { 
+  idToken: '',
+  userId: '',
+  authenticating: true, <- modified by authStart action
+  error: null 
+}
+*/
+console.log(
+  store.dispatch(
+    authSuccess({ idToken: 'really Long Token', userId: 'Its Me' }),
+  ),
+  getAuth(store.getState()),
+);
+// [auth reducer called with undefined state and authSuccess action]
+/* 
+Action: { 
+  type: 'auth/authSuccess',
+  payload: { 
+    idToken: 'really Long Token',
+     userId: 'Its Me'
+     } 
+    }
+
+ New Auth State: {
+  idToken: 'really Long Token', <- modified
+  userId: 'Its Me',             <- modified
+  authenticating: false,        <- modified
+  error: null                   <- not modified
+}
+*/

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "prettier": "prettier --write {src}/*.ts"
   },
   "devDependencies": {
+    "@types/jest": "^23.3.10",
     "@types/node": "^10.9.3",
+    "babel-core": "^6.0.0 || ^7.0.0-0",
+    "babel-jest": "^23.0.0 || ^24.0.0",
     "husky": "^0.14.3",
     "jest": "^23.5.0",
     "lint-staged": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint-staged": "^7.2.0",
     "prettier": "1.13.6",
     "redux": "^4.0.1",
+    "redux-thunk": "^2.3.0",
     "ts-jest": "^23.1.4",
     "typescript": "^3.1.0-dev.20180831"
   },

--- a/src/slice-map.test.ts
+++ b/src/slice-map.test.ts
@@ -16,7 +16,7 @@ describe('mapSlice', () => {
   describe('add', () => {
     it('should add items to map', () => {
       const slice = 'test';
-      const { reducer, actions } = mapSlice<State, Actions>({ slice });
+      const { reducer, actions } = mapSlice<State, Actions>(slice);
       const test = {
         1: 'one',
         2: 'two',
@@ -30,7 +30,7 @@ describe('mapSlice', () => {
   describe('set', () => {
     it('should set items to map', () => {
       const slice = 'test';
-      const { reducer, actions } = mapSlice<State, Actions>({ slice });
+      const { reducer, actions } = mapSlice<State, Actions>(slice);
       const test = {
         1: 'one',
         2: 'two',
@@ -44,7 +44,7 @@ describe('mapSlice', () => {
   describe('remove', () => {
     it('should remove items from map', () => {
       const slice = 'test';
-      const { reducer, actions } = mapSlice<State, Actions>({ slice });
+      const { reducer, actions } = mapSlice<State, Actions>(slice);
       const state = { 1: 'one', 2: 'two', 3: 'three' };
       const actual = reducer(state, actions.removeTest(['1', '2']));
       expect(actual).toEqual({ 3: 'three' });
@@ -54,7 +54,7 @@ describe('mapSlice', () => {
   describe('reset', () => {
     it('should reset map', () => {
       const slice = 'test';
-      const { reducer, actions } = mapSlice<State, Actions>({ slice });
+      const { reducer, actions } = mapSlice<State, Actions>(slice);
       const state = { 1: 'one', 2: 'two', 3: 'three' };
       const actual = reducer(state, actions.resetTest());
       expect(actual).toEqual({});

--- a/src/slice-map.test.ts
+++ b/src/slice-map.test.ts
@@ -6,10 +6,10 @@ interface State {
 }
 
 interface Actions {
-  addTest: (p: State) => Action<State>;
-  setTest: (p: State) => Action<State>;
-  removeTest: (p: string[]) => Action<string[]>;
-  resetTest: () => Action;
+  addTest: State;
+  setTest: State;
+  removeTest: string[];
+  resetTest: null;
 }
 
 describe('mapSlice', () => {

--- a/src/slice-map.ts
+++ b/src/slice-map.ts
@@ -42,6 +42,6 @@ export default function mapSlice<S, M>({ slice }: IMapSlice<S>) {
       [`set${cap(slice)}`]: set<S>(),
       [`remove${cap(slice)}`]: remove<S>(),
       [`reset${cap(slice)}`]: () => initialState,
-    },
+    } as any,
   });
 }

--- a/src/slice-map.ts
+++ b/src/slice-map.ts
@@ -2,10 +2,6 @@ import robodux from './slice';
 
 const cap = (t: string) => t.charAt(0).toUpperCase() + t.substr(1);
 
-interface IMapSlice<S> {
-  slice: string;
-}
-
 type Obj = {
   [key: string]: any;
 };
@@ -32,7 +28,7 @@ function remove<S = Obj>() {
   };
 }
 
-export default function mapSlice<S, M>({ slice }: IMapSlice<S>) {
+export default function mapSlice<S, M = undefined>(slice: string) {
   const initialState = {} as S;
   return robodux<S, M>({
     slice,

--- a/src/slice.test.ts
+++ b/src/slice.test.ts
@@ -5,8 +5,8 @@ describe('createSlice', () => {
   describe('when slice is empty', () => {
     type State = number;
     interface Actions {
-      increment: () => Action;
-      multiply: (payload: number) => Action<number>;
+      increment: null;
+      multiply: number;
     }
     const { actions, reducer, selectors } = createSlice<State, Actions>({
       actions: {
@@ -63,6 +63,7 @@ describe('createSlice', () => {
     const { actions, reducer, selectors } = createSlice({
       actions: {
         increment: (state) => state + 1,
+        multiply: (state: number, payload: number) => state * payload,
       },
       initialState: 0,
       slice: 'cool',
@@ -71,6 +72,9 @@ describe('createSlice', () => {
     it('should create increment action', () => {
       expect(actions.hasOwnProperty('increment')).toBe(true);
     });
+    it('should create multiply action', () => {
+      expect(actions.hasOwnProperty('multiply')).toBe(true);
+    });
 
     it('should have the correct action for increment', () => {
       expect(actions.increment()).toEqual({
@@ -78,9 +82,18 @@ describe('createSlice', () => {
         payload: undefined,
       });
     });
+    it('should have the correct action for multiply', () => {
+      expect(actions.multiply(5)).toEqual({
+        type: 'cool/multiply',
+        payload: 5,
+      });
+    });
 
     it('should return the correct value from reducer', () => {
       expect(reducer(undefined, actions.increment())).toEqual(1);
+    });
+    it('should return the correct value from reducer when multiplying', () => {
+      expect(reducer(5, actions.multiply(5))).toEqual(25);
     });
 
     it('should create selector with correct name', () => {

--- a/src/slice.test.ts
+++ b/src/slice.test.ts
@@ -63,7 +63,7 @@ describe('createSlice', () => {
     const { actions, reducer, selectors } = createSlice({
       actions: {
         increment: (state) => state + 1,
-        multiply: (state: number, payload: number) => state * payload,
+        multiply: (state, payload) => state * payload,
       },
       initialState: 0,
       slice: 'cool',

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -2,30 +2,34 @@ import createAction from './action';
 import createReducer from './reducer';
 import { createSelector, createSelectorName } from './selector';
 import { Action } from './types';
+import { Action as RAction} from 'redux';
 
-type Reduce<State> = (state: State, payload?: any) => State | undefined | void;
+type GetPayloadType<A> = A extends ((payload: infer P) => Action) ? P : A extends ((payload: infer P) => RAction) ? P : A;
+
+type Reduce<State,ActionsMethod = never> = (state: State, payload?: GetPayloadType<ActionsMethod>) => State | undefined | void;
 interface ReduceMap<State> {
   [key: string]: Reduce<State>;
 }
 interface ICreate<State, Actions> {
   slice?: string;
-  actions: { [key: string]: Reduce<State> };
+  actions: { [key in keyof Actions]: Reduce<State, Actions[key]> };
   initialState: State;
 }
 
+interface ActionsObject { [key: string]: (p?: any) => Action | RAction; }
 const actionTypeBuilder = (slice: string) => (action: string) =>
   slice ? `${slice}/${action}` : action;
 
 export default function create<
-  SliceState = any,
-  Actions = { [key: string]: (p?: any) => Action<any> },
-  State = any
->({ slice = '', actions, initialState }: ICreate<SliceState, Actions>) {
+  SliceState,
+  Actions = ActionsObject,
+  State = any,
+>({ slice ='', actions, initialState }: ICreate<SliceState, Actions>) {
   const actionKeys = Object.keys(actions) as (keyof Actions)[];
   const createActionType = actionTypeBuilder(slice);
 
   const reducerMap = actionKeys.reduce<ReduceMap<SliceState>>((map, action) => {
-    map[createActionType(action as string)] = actions[action as string];
+    map[createActionType(action as string)] = actions[action];
     return map;
   }, {});
 
@@ -35,7 +39,7 @@ export default function create<
     slice,
   });
 
-  const actionMap = actionKeys.reduce<{ [A in keyof Actions]: Actions[A] }>(
+  const actionMap = actionKeys.reduce<{ [A in keyof Actions]: Actions[A]  extends Function ? Actions[A] : (p?: any) => Action | RAction}>(
     (map, action) => {
       const type = createActionType(action as string);
       map[action] = createAction(type) as any;
@@ -48,9 +52,8 @@ export default function create<
   const selectors = {
     [selectorName]: createSelector<State, SliceState>(slice),
   };
-
   return {
-    actions: actionMap,
+    actions: actionMap ,
     reducer,
     slice,
     selectors,

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -24,12 +24,13 @@ interface ICreate<State, Actions> {
 const actionTypeBuilder = (slice: string) => (action: string) =>
   slice ? `${slice}/${action}` : action;
 
+type NoUndefinedActions<Actions>  = Actions extends undefined ? {[s:string]:any} : Actions 
 
 export default function create<
   SliceState,
   Actions = undefined,
   State = any
-  >({ slice = '', actions, initialState }: ICreate<SliceState, Actions extends undefined ? {[s:string]:any} :Actions >) {
+  >({ slice = '', actions, initialState }: ICreate<SliceState, NoUndefinedActions<Actions> >) {
   type Ax = Actions extends undefined ?  {[s:string]:any} : Actions
   const actionKeys = Object.keys(actions) as (keyof Ax)[];
   const createActionType = actionTypeBuilder(slice);

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -31,7 +31,7 @@ export default function create<
   Actions = undefined,
   State = any
   >({ slice = '', actions, initialState }: ICreate<SliceState, NoUndefinedActions<Actions> >) {
-  type Ax = Actions extends undefined ?  {[s:string]:any} : Actions
+  type Ax = NoUndefinedActions<Actions>
   const actionKeys = Object.keys(actions) as (keyof Ax)[];
   const createActionType = actionTypeBuilder(slice);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type ActionType = string;
 export interface Action<P = any> {
   readonly type: ActionType;
-  readonly payload?: P;
+  readonly payload: P;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type ActionType = string;
 export interface Action<P = any> {
   readonly type: ActionType;
-  readonly payload: P;
+  readonly payload?: P;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,10 @@
     "sourceMap": true,
     "baseUrl": ".",
     "target": "es5",
-    "module": "commonjs",
+    "module": "esnext",
     "outDir": "./dist",
+    "esModuleInterop": true,
+    "strict": true,
     "moduleResolution": "node",
     "lib": ["es2015", "es2017", "dom"],
     "declaration": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,6 +115,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@types/jest@^23.3.10":
+  version "23.3.10"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.10.tgz#4897974cc317bf99d4fe6af1efa15957fa9c94de"
+  integrity sha512-DC8xTuW/6TYgvEg3HEXS7cu9OijFqprVDXXiOcdOKZCU/5PJNLZU37VVvmZHdtMiGOa8wAA/We+JzbdxFzQTRQ==
+
 "@types/node@^10.9.3":
   version "10.9.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
@@ -329,7 +334,7 @@ babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.0.0, babel-core@^6.26.0:
+babel-core@^6.0.0, "babel-core@^6.0.0 || ^7.0.0-0", babel-core@^6.26.0:
   version "6.26.3"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   integrity sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==
@@ -375,6 +380,14 @@ babel-helpers@^6.24.1:
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
+
+"babel-jest@^23.0.0 || ^24.0.0":
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.6.0.tgz#a644232366557a2240a0c083da6b25786185a2f1"
+  integrity sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==
+  dependencies:
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.2.0"
 
 babel-jest@^23.4.2:
   version "23.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3212,6 +3212,11 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
 redux@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3862,10 +3862,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^3.1.0-dev.20180831:
-  version "3.1.0-dev.20180904"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.0-dev.20180904.tgz#90130204548fef2ec51901657caf74ecac1e3100"
-  integrity sha512-S66rC/Dd6uytkOwjl57yObP1+3FUPZCB4Ljhwku47aCIN9j7fba/Q0DdlXhircaHTdMa+OextXy+gbTSnCHJpg==
+typescript@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
The slice-map update threw me for a loop but I fixed it now 

Anyway this references issue #7 but without the experimental multiple selectors stuff(it works fine but I want better typing)

This pull request simplifies the Action interfaces and adds autocompletion and auto types to the actions object (including the actions object in `robodux({ actions: {..} })` ) and eliminates the need to specify payload type twice. 

The reason the Actions generic in create defaults to undefined is so I can properly check if an Actions interface was provided and output actions types with optional payload arguments