### PR TITLE
slice no type

### DIFF
--- a/src/slice-map.test.ts
+++ b/src/slice-map.test.ts
@@ -15,7 +15,7 @@ describe('mapSlice', () => {
   describe('add', () => {
     it('should add items to map', () => {
       const slice = 'test';
-      const { reducer, actions } = mapSlice<State, Actions>(slice);
+      const { reducer, actions } = mapSlice<State, Actions>({ slice });
       const test = {
         1: 'one',
         2: 'two',
@@ -29,7 +29,7 @@ describe('mapSlice', () => {
   describe('set', () => {
     it('should set items to map', () => {
       const slice = 'test';
-      const { reducer, actions } = mapSlice<State, Actions, any>(slice);
+      const { reducer, actions } = mapSlice<State, Actions, any>({ slice });
       const test = {
         1: 'one',
         2: 'two',
@@ -43,7 +43,7 @@ describe('mapSlice', () => {
   describe('remove', () => {
     it('should remove items from map', () => {
       const slice = 'test';
-      const { reducer, actions } = mapSlice<State, Actions, any>(slice);
+      const { reducer, actions } = mapSlice<State, Actions, any>({ slice });
       const state = { 1: 'one', 2: 'two', 3: 'three' };
       const actual = reducer(state, actions.removeTest(['1', '2']));
       expect(actual).toEqual({ 3: 'three' });
@@ -53,7 +53,7 @@ describe('mapSlice', () => {
   describe('reset', () => {
     it('should reset map', () => {
       const slice = 'test';
-      const { reducer, actions } = mapSlice<State, Actions, any>(slice);
+      const { reducer, actions } = mapSlice<State, Actions, any>({ slice });
       const state = { 1: 'one', 2: 'two', 3: 'three' };
       const actual = reducer(state, actions.resetTest());
       expect(actual).toEqual({});

--- a/src/slice-map.ts
+++ b/src/slice-map.ts
@@ -33,7 +33,7 @@ export default function mapSlice<
   SS extends AnyState = any,
   A = any,
   S extends AnyState = any
->(slice: keyof S) {
+>({ slice }: { slice: keyof S }) {
   const initialState = {} as NoEmptyArray<SS>;
   return robodux<SS, A, S>({
     slice,

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -52,6 +52,11 @@ export interface Slice<A = any, SS = any, S = SS, str = ''> {
   };
 }
 
+interface InputWithSliceNoType<SS = any, Ax = ActionsAny> {
+  initialState: SS;
+  actions: ActionsObjWithSlice<SS, Ax>;
+  slice: string;
+}
 interface InputWithSlice<SS = any, Ax = ActionsAny, S = any> {
   initialState: SS;
   actions: ActionsObjWithSlice<SS, Ax, S>;
@@ -75,6 +80,14 @@ interface InputWithOptionalSlice<SS = any, Ax = ActionsAny, S = any> {
 const actionTypeBuilder = (slice: string) => (action: string) =>
   slice ? `${slice}/${action}` : action;
 
+export default function createSlice<SliceState, Actions extends ActionsAny>({
+  actions,
+  initialState,
+  slice,
+}: InputWithSliceNoType<NoEmptyArray<SliceState>, Actions>): Slice<
+  Actions,
+  NoEmptyArray<SliceState>
+>;
 export default function createSlice<
   SliceState,
   Actions extends ActionsAny,
@@ -100,7 +113,6 @@ export default function createSlice<SliceState, Actions extends ActionsAny>({
   NoEmptyArray<SliceState>,
   typeof slice
 >;
-
 export default function createSlice<SliceState, Actions extends ActionsAny>({
   actions,
   initialState,

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -38,11 +38,13 @@ export interface ReducerMap<SS, A = Action> {
   [Action: string]: ActionReducer<SS, A>;
 }
 
+type NoBadState<S> = S extends { [x: string]: {} } ? AnyState : S;
+
 export interface Slice<A = any, SS = any, S = SS, str = ''> {
   slice: SS extends S ? '' : str;
   reducer: Reducer<SS, Action>;
   selectors: {
-    getSlice: (state: S) => SS;
+    getSlice: (state: NoBadState<S>) => SS;
   };
   actions: {
     [key in keyof A]: Object extends A[key] // ensures payload isn't inferred as {}
@@ -53,6 +55,11 @@ export interface Slice<A = any, SS = any, S = SS, str = ''> {
   };
 }
 
+interface InputWithBlankSlice<SS = any, Ax = ActionsAny> {
+  initialState: SS;
+  actions: ActionsObj<SS, Ax>;
+  slice: '';
+}
 interface InputWithSlice<SS = any, Ax = ActionsAny, S = any> {
   initialState: SS;
   actions: ActionsObjWithSlice<SS, Ax, S>;
@@ -70,6 +77,21 @@ interface InputWithOptionalSlice<SS = any, Ax = ActionsAny, S = any> {
 
 const actionTypeBuilder = (slice: string) => (action: string) =>
   slice ? `${slice}/${action}` : action;
+
+export default function createSlice<
+  SliceState,
+  Actions extends ActionsAny,
+  State extends AnyState
+>({
+  actions,
+  initialState,
+  slice,
+}: InputWithBlankSlice<NoEmptyArray<SliceState>, Actions>): Slice<
+  Actions,
+  NoEmptyArray<SliceState>,
+  NoEmptyArray<State>,
+  typeof slice
+>;
 
 export default function createSlice<
   SliceState,

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -29,6 +29,7 @@ type ActionsObjWithSlice<SS = any, Ax = any, S = any> = {
 interface ActionsAny<P = any> {
   [Action: string]: P;
 }
+
 export interface AnyState {
   [slice: string]: any;
 }
@@ -52,11 +53,6 @@ export interface Slice<A = any, SS = any, S = SS, str = ''> {
   };
 }
 
-interface InputWithSliceNoType<SS = any, Ax = ActionsAny> {
-  initialState: SS;
-  actions: ActionsObjWithSlice<SS, Ax>;
-  slice: string;
-}
 interface InputWithSlice<SS = any, Ax = ActionsAny, S = any> {
   initialState: SS;
   actions: ActionsObjWithSlice<SS, Ax, S>;
@@ -65,11 +61,6 @@ interface InputWithSlice<SS = any, Ax = ActionsAny, S = any> {
 interface InputWithoutSlice<SS = any, Ax = ActionsAny> {
   initialState: SS;
   actions: ActionsObj<SS, Ax>;
-}
-interface InputWithBlankSlice<SS = any, Ax = ActionsAny> {
-  initialState: SS;
-  actions: ActionsObj<SS, Ax>;
-  slice: '';
 }
 interface InputWithOptionalSlice<SS = any, Ax = ActionsAny, S = any> {
   initialState: SS;
@@ -80,14 +71,6 @@ interface InputWithOptionalSlice<SS = any, Ax = ActionsAny, S = any> {
 const actionTypeBuilder = (slice: string) => (action: string) =>
   slice ? `${slice}/${action}` : action;
 
-export default function createSlice<SliceState, Actions extends ActionsAny>({
-  actions,
-  initialState,
-  slice,
-}: InputWithSliceNoType<NoEmptyArray<SliceState>, Actions>): Slice<
-  Actions,
-  NoEmptyArray<SliceState>
->;
 export default function createSlice<
   SliceState,
   Actions extends ActionsAny,
@@ -103,22 +86,17 @@ export default function createSlice<
   typeof slice
 >;
 
-export default function createSlice<SliceState, Actions extends ActionsAny>({
-  actions,
-  initialState,
-  slice,
-}: InputWithBlankSlice<NoEmptyArray<SliceState>, Actions>): Slice<
-  Actions,
-  NoEmptyArray<SliceState>,
-  NoEmptyArray<SliceState>,
-  typeof slice
->;
-export default function createSlice<SliceState, Actions extends ActionsAny>({
+export default function createSlice<
+  SliceState,
+  Actions extends ActionsAny,
+  State = SliceState
+>({
   actions,
   initialState,
 }: InputWithoutSlice<NoEmptyArray<SliceState>, Actions>): Slice<
   Actions,
-  NoEmptyArray<SliceState>
+  NoEmptyArray<SliceState>,
+  State
 >;
 
 export default function createSlice<
@@ -167,6 +145,7 @@ export default function createSlice<
   const selectors = {
     getSlice: createSelector<State, SliceState>(<string>slice),
   };
+
   return {
     actions: actionMap,
     reducer,


### PR DESCRIPTION
* Converted `mapSlice` params from string to object (going to eventually allow initialState to be passed)
* Added interface `InputSliceNoType` for when you don't want to pass in redux state but still want a slice

@Dudeonyx 