### PR TITLE
:sparkles: make immer optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ console.log(counter.selectors.getCounter(state));
 // -> 6
 ```
 
+Without immer:
+
+```js
+const user = robodux<User, UserActions, State>({
+  slice: 'user', // slice is optional could be blank ''
+  initialState: { name: '' },
+  actions: {
+    setUserName: (state, payload) => {
+      return { ...state, name: payload }
+    },
+  },
+  useImmer: false,
+})
+
+
+```
+
 ## Types
 
 `robodux` accepts three generics: `SliceState`, `Actions`, `State`.
@@ -307,12 +324,13 @@ pass around action creators for reducers, sagas, etc.
 ```js
 import { createAction } from 'robodux';
 
-const increment = createAction('INCREMENT');
+const increment = createAction<number, 'INCREMENT'>('INCREMENT');
 console.log(increment);
 // -> 'INCREMENT'
 console.log(increment(2));
 // { type: 'INCREMENT', payload: 2 };
-const storeDetails = createAction('STORE_DETAILS');
+const detailType = 'STORE_DETAILS';
+const storeDetails = createAction<{ name: string, surname: string }, typeof detailType>(detailType);
 console.log(storeDetails);
 // -> 'STORE_DETAILS'
 console.log(storeDetails({name: 'John', surname: 'Doe'}));
@@ -334,6 +352,25 @@ const counter = createReducer({
     DECREMENT: (state) => state - 1,
     MULTIPLY: (state, payload) => state * payload,
   }
+});
+
+console.log(counter(2, { type: 'MULTIPLY': payload: 5 }));
+// -> 10
+```
+
+Without `immer`
+
+```js
+import { createReducer } from 'robodux';
+
+const counter = createReducer({
+  initialState: 0,
+  actions: {
+    INCREMENT: (state) => state + 1,
+    DECREMENT: (state) => state - 1,
+    MULTIPLY: (state, payload) => state * payload,
+  },
+  useImmer: false,
 });
 
 console.log(counter(2, { type: 'MULTIPLY': payload: 5 }));

--- a/src/action.ts
+++ b/src/action.ts
@@ -22,6 +22,7 @@ export default function creator<P = any, T extends string = string>(
   }
 
   action.toString = (): T => `${type}` as T;
+  action.type = type;
   return action;
 }
 

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -7,6 +7,7 @@ export type CreateReducer<SS = any> = {
   initialState: SS;
   actions: ReducerMap<SS, any>;
   slice?: string;
+  useImmer?: boolean;
 };
 
 export type NoEmptyArray<State> = State extends never[] ? any[] : State;
@@ -15,19 +16,27 @@ export default function createReducer<S, SS extends S = any>({
   initialState,
   actions,
   slice = '',
+  useImmer = true,
 }: CreateReducer<NoEmptyArray<SS>>) {
-  const reducer = (state = initialState, action: Action<any>) => {
+  const reducerPlain = (state = initialState, action: Action<any>) => {
+    const caseReducer = actions[action.type];
+    if (!caseReducer) {
+      return state;
+    }
+    return caseReducer(state as NoEmptyArray<SS>, action.payload);
+  };
+
+  const reducerImmer = (state = initialState, action: Action<any>) => {
     return createNextState(state, (draft) => {
       const caseReducer = actions[action.type];
-
-      if (caseReducer) {
-        return caseReducer(draft as NoEmptyArray<SS>, action.payload);
+      if (!caseReducer) {
+        return draft;
       }
-
-      return draft;
+      return caseReducer(draft as NoEmptyArray<SS>, action.payload);
     });
   };
 
+  const reducer = useImmer ? reducerImmer : reducerPlain;
   reducer.toString = () => slice;
   return reducer;
 }

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -42,6 +42,7 @@ type NoBadState<S> = S extends { [x: string]: {} } ? AnyState : S;
 
 export interface Slice<A = any, SS = any, S = SS, str = ''> {
   slice: SS extends S ? '' : str;
+  userImmer?: boolean;
   reducer: Reducer<SS, Action>;
   selectors: { getSlice: (state: NoBadState<S>) => SS };
   actions: {
@@ -57,20 +58,24 @@ interface InputWithBlankSlice<SS = any, Ax = ActionsAny> {
   initialState: SS;
   actions: ActionsObj<SS, Ax>;
   slice: '';
+  useImmer?: boolean;
 }
 interface InputWithSlice<SS = any, Ax = ActionsAny, S = any> {
   initialState: SS;
   actions: ActionsObjWithSlice<SS, Ax, S>;
   slice: keyof S;
+  useImmer?: boolean;
 }
 interface InputWithoutSlice<SS = any, Ax = ActionsAny> {
   initialState: SS;
   actions: ActionsObj<SS, Ax>;
+  useImmer?: boolean;
 }
 interface InputWithOptionalSlice<SS = any, Ax = ActionsAny, S = any> {
   initialState: SS;
   actions: ActionsObjWithSlice<SS, Ax, S>;
   slice?: keyof S;
+  useImmer?: boolean;
 }
 
 const actionTypeBuilder = (slice: string) => (action: string) =>
@@ -129,6 +134,7 @@ export default function createSlice<
   actions,
   initialState,
   slice = '',
+  useImmer = true,
 }: InputWithOptionalSlice<NoEmptyArray<SliceState>, Actions, State>) {
   const actionKeys = Object.keys(actions) as (keyof Actions)[];
   const createActionType = actionTypeBuilder(<string>slice);
@@ -145,6 +151,7 @@ export default function createSlice<
     initialState,
     actions: reducerMap,
     slice: <string>slice,
+    useImmer,
   });
 
   const actionMap = actionKeys.reduce<


### PR DESCRIPTION
This allows `immer` to be optional in reducers.  For simple reducers, it is pointless to use `immer` since they are simple sets, add, etc.  Furthermore, `mapSlice` doesn't need `immer` and could create unnecessary overhead.