### PR TITLE
update README with peer dependency info

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,11 @@
 yarn add robodux
 ```
 
+If you don't already have `redux` and `immer` installed, you'll need to install those as well as they're peer dependencies.
+```bash
+yarn add redux immer
+```
+
 _NOTE_: we officially support Typescript.
 
 The primary philosophical change between this library and other libraries is to


### PR DESCRIPTION
when I was installing robodux in a new project, I got the error in the screenshot. After installing immer with `yarn add immer`, everything worked.

Question: I see immer is a peer dependency at version `4.0.0`, but the latest version of immer is `5.3.3.`. Should the version in your robodux package.json be updated or should users of robodux use that earlier version? Or does it not matter and version 5.3.3 is fine to use with robodux?

<img width="584" alt="Screen Shot 2020-02-04 at 2 51 15 PM" src="https://user-images.githubusercontent.com/11993240/73794681-d0de9480-475d-11ea-9d0a-e6f8b9a50b84.png">