### PR TITLE
Better loading slice

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -159,13 +159,14 @@ import { loadingSlice, LoadingItemState } from 'robodux';
 
 const { actions, reducer } = loadingSlice({ name: 'loading' });
 store.dispatch(actions.loading('something loading'));
-// redux state: { loading: { error: '', message: 'something loading', loading: true, success: false } }
+// timestamps as unix timestamps
+// redux state: { loading: { error: false, message: 'something loading', loading: true, success: false, timestamp: 0 } }
 
 store.dispatch(actions.success('great success'));
-// redux state: { loading: { error: '', message: 'great success', loading: false, success: true } }
+// redux state: { loading: { error: false, message: 'great success', loading: false, success: true, timestamp: 0  } }
 
 store.dispatch(actions.error('something happened'));
-// redux state: { loading: { error: 'something happened', loading: false, success: false } }
+// redux state: { loading: { error: 'something happened', loading: false, success: false, timestamp: 0 } }
 ```
 
 _NOTE_: We do **not** use `immer` for any slice helpers. Since they are highly

--- a/docs/api.md
+++ b/docs/api.md
@@ -39,8 +39,9 @@ store.disptch(setLoaderStart({ id: 'users' }));
     users: {
       loading: true,
       success: false,
-      error: '',
+      error: false,
       message: '',
+      timestamp: {unix}
     }
   }
 }
@@ -53,8 +54,9 @@ store.dispatch(setLoaderSuccess({ id: 'users', message: 'you did it!' }));
     users: {
       loading: false,
       success: true,
-      error: '',
+      error: false,
       message: 'you did it!',
+      timestamp: {unix}
     }
   }
 }

--- a/src/slice-loading-map.test.ts
+++ b/src/slice-loading-map.test.ts
@@ -10,7 +10,17 @@ const buildLoader = (overrides: Partial<State> = {}) =>
     ...overrides,
   });
 
+const actualDate = Date.now;
+
 describe('loaderMapSlice', () => {
+  beforeEach(() => {
+    Date.now = () => 123;
+  });
+
+  afterEach(() => {
+    Date.now = actualDate;
+  });
+
   it('handles loading without a channel', () => {
     const { reducer, actions } = buildLoader();
 
@@ -18,8 +28,9 @@ describe('loaderMapSlice', () => {
       default: {
         loading: true,
         success: false,
-        error: '',
+        error: false,
         message: '',
+        timestamp: 123,
       },
     });
   });
@@ -31,8 +42,9 @@ describe('loaderMapSlice', () => {
       default: {
         loading: false,
         success: true,
-        error: '',
+        error: false,
         message: '',
+        timestamp: 123,
       },
     });
   });
@@ -41,16 +53,14 @@ describe('loaderMapSlice', () => {
     const { reducer, actions } = buildLoader();
 
     expect(
-      reducer(
-        {},
-        actions.error({ id: 'default', error: 'foo', message: 'foobar' }),
-      ),
+      reducer({}, actions.error({ id: 'default', message: 'foobar' })),
     ).toEqual({
       default: {
         loading: false,
         success: false,
-        error: 'foo',
+        error: true,
         message: 'foobar',
+        timestamp: 123,
       },
     });
   });
@@ -64,8 +74,9 @@ describe('loaderMapSlice', () => {
           default: {
             loading: true,
             success: true,
-            error: 'an error that will be cleared',
+            error: true,
             message: 'a message that will be cleared',
+            timestamp: 0,
           },
         },
         actions.resetById('default'),
@@ -84,8 +95,9 @@ describe('loaderMapSlice', () => {
           default: {
             loading: true,
             success: true,
-            error: 'an error that will be cleared',
+            error: true,
             message: 'a message that will be cleared',
+            timestamp: 0,
           },
         },
         actions.resetAll(),

--- a/src/slice-loading-map.ts
+++ b/src/slice-loading-map.ts
@@ -8,28 +8,28 @@ import {
   defaultLoadingItem,
 } from './slice-loading';
 
-interface State<M, E> {
-  [key: string]: LoadingItemState<M, E>;
+interface State<M> {
+  [key: string]: LoadingItemState<M>;
 }
 
-export type LoadingMapPayload<M, E> = LoadingPayload<M, E> & { id: string };
+export type LoadingMapPayload<M> = LoadingPayload<M> & { id: string };
 
-function reducerCreator<M, E>(
+function reducerCreator<M>(
   reducer: (
-    s: LoadingItemState<M, E>,
-    p: LoadingPayload<M, E>,
-  ) => LoadingItemState<M, E>,
+    s: LoadingItemState<M>,
+    p: LoadingPayload<M>,
+  ) => LoadingItemState<M>,
 ) {
-  return (state: State<M, E>, payload: LoadingMapPayload<M, E>) => ({
+  return (state: State<M>, payload: LoadingMapPayload<M>) => ({
     ...state,
     [payload.id]: reducer(state[payload.id], payload),
   });
 }
 
-interface LoadingMapActions<M = string, E = string> {
-  loading: LoadingMapPayload<M, E>;
-  success: LoadingMapPayload<M, E>;
-  error: LoadingMapPayload<M, E>;
+interface LoadingMapActions<M = string> {
+  loading: LoadingMapPayload<M>;
+  success: LoadingMapPayload<M>;
+  error: LoadingMapPayload<M>;
   remove: string[];
   resetById: string;
   resetAll: never;
@@ -39,20 +39,20 @@ export default function loadingSliceMap({
   name,
   initialState = {},
   extraReducers,
-}: SliceHelper<State<string, string>>) {
-  const loading = loadingReducers<string, string>(defaultLoadingItem());
+}: SliceHelper<State<string>>) {
+  const loading = loadingReducers<string>(defaultLoadingItem());
   const map = mapReducers(initialState);
 
-  return createSlice<State<string, string>, LoadingMapActions<string, string>>({
+  return createSlice<State<string>, LoadingMapActions<string>>({
     name,
     initialState,
     extraReducers,
     useImmer: false,
     reducts: {
-      loading: reducerCreator<string, string>(loading.loading),
-      success: reducerCreator<string, string>(loading.success),
-      error: reducerCreator<string, string>(loading.error),
-      resetById: (state: State<string, string>, id: string) => ({
+      loading: reducerCreator<string>(loading.loading),
+      success: reducerCreator<string>(loading.success),
+      error: reducerCreator<string>(loading.error),
+      resetById: (state: State<string>, id: string) => ({
         ...state,
         [id]: loading.reset(),
       }),

--- a/src/slice-loading.test.ts
+++ b/src/slice-loading.test.ts
@@ -8,18 +8,20 @@ describe('loadingSlice', () => {
       const name = 'loading';
       const { reducer, actions } = loadingSlice({ name });
       const state = freeze({
-        error: '',
+        error: false,
         message: '',
         loading: false,
         success: false,
+        timestamp: 0,
       });
-      const actual = reducer(state, actions.loading());
+      const actual = reducer(state, actions.loading({ timestamp: 1 }));
 
       expect(actual).toEqual({
         loading: true,
-        error: '',
+        error: false,
         message: '',
         success: false,
+        timestamp: 1,
       });
     });
 
@@ -27,39 +29,46 @@ describe('loadingSlice', () => {
       const name = 'loading';
       const { reducer, actions } = loadingSlice({ name });
       const state = freeze({
-        error: '',
+        error: false,
         message: '',
         loading: false,
         success: false,
+        timestamp: 0,
       });
-      const actual = reducer(state, actions.loading({ message: 'hi there' }));
+      const actual = reducer(
+        state,
+        actions.loading({ message: 'hi there', timestamp: 2 }),
+      );
 
       expect(actual).toEqual({
         loading: true,
-        error: '',
+        error: false,
         message: 'hi there',
         success: false,
+        timestamp: 2,
       });
     });
   });
 
   describe('success', () => {
-    it('should set the state to loading', () => {
+    it('should set the state to success', () => {
       const name = 'loading';
       const { reducer, actions } = loadingSlice({ name });
       const state = freeze({
-        error: '',
+        error: false,
         message: '',
         loading: true,
         success: false,
+        timestamp: 0,
       });
-      const actual = reducer(state, actions.success());
+      const actual = reducer(state, actions.success({ timestamp: 5 }));
 
       expect(actual).toEqual({
         loading: false,
-        error: '',
+        error: false,
         message: '',
         success: true,
+        timestamp: 5,
       });
     });
 
@@ -67,18 +76,48 @@ describe('loadingSlice', () => {
       const name = 'loading';
       const { reducer, actions } = loadingSlice({ name });
       const state = freeze({
-        error: '',
+        error: false,
         message: '',
         loading: true,
         success: false,
+        timestamp: 0,
       });
-      const actual = reducer(state, actions.success({ message: 'wow' }));
+      const actual = reducer(
+        state,
+        actions.success({ message: 'wow', timestamp: 2 }),
+      );
 
       expect(actual).toEqual({
         loading: false,
-        error: '',
+        error: false,
         message: 'wow',
         success: true,
+        timestamp: 2,
+      });
+    });
+
+    it('should set the state to success with timestamp', () => {
+      const name = 'loading';
+      const { reducer, actions } = loadingSlice({ name });
+      const state = freeze({
+        error: false,
+        message: '',
+        loading: true,
+        success: false,
+        timestamp: 0,
+      });
+
+      const actualNow = Date.now;
+      Date.now = () => 123;
+      const actual = reducer(state, actions.success());
+      Date.now = actualNow;
+
+      expect(actual).toEqual({
+        loading: false,
+        error: false,
+        message: '',
+        success: true,
+        timestamp: 123,
       });
     });
   });
@@ -87,18 +126,23 @@ describe('loadingSlice', () => {
     const name = 'loading';
     const { reducer, actions } = loadingSlice({ name });
     const state = freeze({
-      error: '',
+      error: false,
       message: 'cool',
       loading: true,
       success: false,
+      timestamp: 0,
     });
-    const actual = reducer(state, actions.error({ error: 'some error' }));
+    const actual = reducer(
+      state,
+      actions.error({ message: 'something', timestamp: 3 }),
+    );
 
     expect(actual).toEqual({
       loading: false,
-      message: '',
-      error: 'some error',
+      message: 'something',
+      error: true,
       success: false,
+      timestamp: 3,
     });
   });
 });

--- a/src/slice-loading.ts
+++ b/src/slice-loading.ts
@@ -2,64 +2,68 @@ import createSlice from './create-slice';
 import { Action, SliceHelper } from './types';
 import { Reducer } from 'redux';
 
-export function loadingReducers<M, E>(initialState: LoadingItemState<M, E>) {
+const ts = () => Date.now();
+
+export function loadingReducers<M>(initialState: LoadingItemState<M>) {
   return {
     success: (
-      state: LoadingItemState<any, any>,
-      payload: LoadingPayload<M, E> = {},
+      state: LoadingItemState<any>,
+      payload: LoadingPayload<M> = {},
     ) => ({
-      error: payload.error || initialState.error,
+      error: false,
       message: payload.message || initialState.message,
       loading: false,
       success: true,
+      timestamp: payload.timestamp || ts(),
     }),
-    error: (
-      state: LoadingItemState<any, any>,
-      payload: LoadingPayload<M, E> = {},
-    ) => ({
-      error: payload.error || initialState.error,
+    error: (state: LoadingItemState<any>, payload: LoadingPayload<M> = {}) => ({
+      error: true,
       message: payload.message || initialState.message,
       loading: false,
       success: false,
+      timestamp: payload.timestamp || ts(),
     }),
     loading: (
-      state: LoadingItemState<any, any>,
-      payload: LoadingPayload<M, E> = {},
+      state: LoadingItemState<any>,
+      payload: LoadingPayload<M> = {},
     ) => ({
-      error: payload.error || initialState.error,
+      error: false,
       message: payload.message || initialState.message,
       loading: true,
       success: false,
+      timestamp: payload.timestamp || ts(),
     }),
     reset: () => initialState,
   };
 }
 
-export interface LoadingItemState<M = string, E = string> {
+export interface LoadingItemState<M = string> {
   message: M;
-  error: E;
+  error: boolean;
   loading: boolean;
   success: boolean;
+  timestamp: number;
 }
 
-export function defaultLoadingItem(): LoadingItemState<string, string> {
+export function defaultLoadingItem(): LoadingItemState<string> {
   return {
-    error: '',
+    error: false,
     message: '',
     loading: false,
     success: false,
+    timestamp: ts(),
   };
 }
 
-export type LoadingPayload<M = string, E = string> = Partial<{
-  error: E;
+export type LoadingPayload<M = string> = Partial<{
   message: M;
+  timestamp: number;
 }>;
 
-interface LoadingActions<M = string, E = string> {
-  loading: LoadingPayload<M, E>;
-  success: LoadingPayload<M, E>;
-  error: LoadingPayload<M, E>;
+interface LoadingActions<M = string> {
+  loading: LoadingPayload<M>;
+  success: LoadingPayload<M>;
+  error: LoadingPayload<M>;
   reset: never;
 }
 
@@ -67,34 +71,31 @@ export default function loadingSlice({
   name,
   initialState,
   extraReducers,
-}: SliceHelper<LoadingItemState<string, string>>): {
+}: SliceHelper<LoadingItemState<string>>): {
   name: string;
-  reducer: Reducer<LoadingItemState<string, string>, Action>;
+  reducer: Reducer<LoadingItemState<string>, Action>;
   actions: {
-    [key in keyof LoadingActions<string, string>]: LoadingActions<
-      string,
+    [key in keyof LoadingActions<string>]: LoadingActions<
       string
     >[key] extends never
       ? () => Action
       : (
-          payload?: LoadingActions<string, string>[key],
-        ) => Action<LoadingActions<string, string>[key]>;
+          payload?: LoadingActions<string>[key],
+        ) => Action<LoadingActions<string>[key]>;
   };
   toString: () => string;
 };
-export default function loadingSlice<M, E>({
+export default function loadingSlice<M>({
   name,
   initialState,
   extraReducers,
-}: SliceHelper<LoadingItemState<M, E>>): {
+}: SliceHelper<LoadingItemState<M>>): {
   name: string;
-  reducer: Reducer<LoadingItemState<M, E>, Action>;
+  reducer: Reducer<LoadingItemState<M>, Action>;
   actions: {
-    [key in keyof LoadingActions<M, E>]: LoadingActions<M, E>[key] extends never
+    [key in keyof LoadingActions<M>]: LoadingActions<M>[key] extends never
       ? () => Action
-      : (
-          payload?: LoadingActions<M, E>[key],
-        ) => Action<LoadingActions<M, E>[key]>;
+      : (payload?: LoadingActions<M>[key]) => Action<LoadingActions<M>[key]>;
   };
   toString: () => string;
 };
@@ -102,8 +103,8 @@ export default function loadingSlice({
   name,
   initialState = defaultLoadingItem(),
   extraReducers,
-}: SliceHelper<LoadingItemState<any, any>>) {
-  return createSlice<LoadingItemState<any, any>, LoadingActions<any, any>>({
+}: SliceHelper<LoadingItemState<any>>) {
+  return createSlice<LoadingItemState<any>, LoadingActions<any>>({
     name,
     initialState,
     extraReducers,

--- a/type-tests/slice-loading.ts
+++ b/type-tests/slice-loading.ts
@@ -1,42 +1,41 @@
 import loadingSlice from '../src/slice-loading';
 
 const one = loadingSlice({ name: 'SLICE' });
-// $ExpectType { loading: (payload?: Partial<{ error: string; message: string; }> | undefined) => Action<Partial<{ error: string; message: string; }>, string>; success: (payload?: Partial<{ error: string; message: string; }> | undefined) => Action<...>; error: (payload?: Partial<...> | undefined) => Action<...>; reset: () => Actio...
+// $ExpectType { loading: (payload?: Partial<{ message: string; timestamp: number; }> | undefined) => Action<Partial<{ message: string; timestamp: number; }>, string>; success: (payload?: Partial<{ message: string; timestamp: number; }> | undefined) => Action<...>; error: (payload?: Partial<...> | undefined) => Action<...>; reset:...
 one.actions;
-// $ExpectType (payload?: Partial<{ error: string; message: string; }> | undefined) => Action<Partial<{ error: string; message: string; }>, string>
+// $ExpectType (payload?: Partial<{ message: string; timestamp: number; }> | undefined) => Action<Partial<{ message: string; timestamp: number; }>, string>
 one.actions.loading;
 one.actions.loading();
-// $ExpectType (payload?: Partial<{ error: string; message: string; }> | undefined) => Action<Partial<{ error: string; message: string; }>, string>
+// $ExpectType (payload?: Partial<{ message: string; timestamp: number; }> | undefined) => Action<Partial<{ message: string; timestamp: number; }>, string>
 one.actions.success;
 one.actions.success();
-// $ExpectType (payload?: Partial<{ error: string; message: string; }> | undefined) => Action<Partial<{ error: string; message: string; }>, string>
+// $ExpectType (payload?: Partial<{ message: string; timestamp: number; }> | undefined) => Action<Partial<{ message: string; timestamp: number; }>, string>
 one.actions.error;
 one.actions.error();
-// $ExpectType Reducer<LoadingItemState<string, string>, Action<any, string>>
+// $ExpectType Reducer<LoadingItemState<string>, Action<any, string>>
 one.reducer;
 
 const withPayload = loadingSlice({ name: 'SLICE' });
-// $ExpectType { loading: (payload?: Partial<{ error: string; message: string; }> | undefined) => Action<Partial<{ error: string; message: string; }>, string>; success: (payload?: Partial<{ error: string; message: string; }> | undefined) => Action<...>; error: (payload?: Partial<...> | undefined) => Action<...>; reset: () => Actio...
+// $ExpectType { loading: (payload?: Partial<{ message: string; timestamp: number; }> | undefined) => Action<Partial<{ message: string; timestamp: number; }>, string>; success: (payload?: Partial<{ message: string; timestamp: number; }> | undefined) => Action<...>; error: (payload?: Partial<...> | undefined) => Action<...>; reset:...
 withPayload.actions;
 withPayload.actions.loading({ message: 'hi' });
-withPayload.actions.success({ error: 'nice' });
-withPayload.actions.error({ message: 'hi', error: 'nice' });
-// $ExpectType Reducer<LoadingItemState<string, string>, Action<any, string>>
+withPayload.actions.success({ message: 'nice' });
+withPayload.actions.error({ message: 'hi' });
+// $ExpectType Reducer<LoadingItemState<string>, Action<any, string>>
 withPayload.reducer;
 
-const two = loadingSlice<string, Error | null>({
+const two = loadingSlice<string>({
   name: 'SLICE',
   initialState: {
     message: '',
-    error: null,
+    error: false,
     success: false,
     loading: false,
+    timestamp: 0,
   },
 });
-// $ExpectType { loading: (payload?: Partial<{ error: Error | null; message: string; }> | undefined) => Action<Partial<{ error: Error | null; message: string; }>, string>; success: (payload?: Partial<{ error: Error | null; message: string; }> | undefined) => Action<...>; error: (payload?: Partial<...> | undefined) => Action<...>; ...
 two.actions;
-// two.actions.success({ message: 'ok', error: 'sdsd' });
-two.actions.error({ message: 'ok', error: new Error('sdsd') });
-two.actions.loading({ error: new Error('sdsd') });
-// $ExpectType Reducer<LoadingItemState<string, Error | null>, Action<any, string>>
+two.actions.error({ message: 'ok' });
+two.actions.loading({ message: 'loading' });
+// $ExpectType Reducer<LoadingItemState<string>, Action<any, string>>
 two.reducer;


### PR DESCRIPTION
The goal of this PR is to improve the loader experience.  Making `error` a string by default was a mistake.  It makes more sense for it to be a boolean and let the `message` property contain information.

The `message` property is generic so end-developer can choose what they want it to be.  For example if they want to allow strings or `Error`.

I also added a `timestamp` which uses unix timestamp to track each time the loader changes.