### PR TITLE
createTable API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@
   helpers
 - :boom: renamed `slice` to `name` for `createSlice`, `createReducers` and all
   slice helpers
-- :boom: renamed `actions` to `reducts` for `createSlice` to signal that it is a
+- :boom: renamed `actions` to `reducers` for `createSlice` to signal that it is a
   mapping between action names and reducers: `reducer` + `action` = `reduct`
 - :sparkles: `createActionMap` helper function to combine actions from multiple
   slices

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {},
   "peerDependencies": {
     "immer": "^4.0.0",
-    "redux": "^4.0.4"
+    "redux": "^4.0.4",
+    "reselect": "^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/src/create-assign.ts
+++ b/src/create-assign.ts
@@ -22,7 +22,7 @@ export default function createAssign<State = any>({
     name,
     useImmer: false,
     initialState,
-    reducts: assignReducers(initialState),
+    reducers: assignReducers(initialState),
     extraReducers,
   });
 }

--- a/src/create-list.ts
+++ b/src/create-list.ts
@@ -35,7 +35,7 @@ export default function createList<State extends any[]>({
     initialState,
     extraReducers,
     useImmer: false,
-    reducts: listReducers(initialState),
+    reducers: listReducers(initialState),
   });
 
   return slice;

--- a/src/create-loader-table.ts
+++ b/src/create-loader-table.ts
@@ -1,6 +1,6 @@
 import createSlice from './create-slice';
 import { SliceHelper } from './types';
-import { tableReducers } from './create-table';
+import { mapReducers } from './create-map';
 import {
   LoadingItemState,
   LoadingPayload,
@@ -41,14 +41,14 @@ export default function createLoaderTable({
   extraReducers,
 }: SliceHelper<State<string>>) {
   const loading = loadingReducers<string>(defaultLoadingItem());
-  const map = tableReducers(initialState);
+  const map = mapReducers(initialState);
 
   return createSlice<State<string>, LoadingMapActions<string>>({
     name,
     initialState,
     extraReducers,
     useImmer: false,
-    reducts: {
+    reducers: {
       loading: reducerCreator<string>(loading.loading),
       success: reducerCreator<string>(loading.success),
       error: reducerCreator<string>(loading.error),

--- a/src/create-loader.ts
+++ b/src/create-loader.ts
@@ -120,6 +120,6 @@ export default function createLoader({
     initialState,
     extraReducers,
     useImmer: false,
-    reducts: loadingReducers(initialState),
+    reducers: loadingReducers(initialState),
   });
 }

--- a/src/create-map.test.ts
+++ b/src/create-map.test.ts
@@ -1,0 +1,101 @@
+import createMap from './create-map';
+import deepFreeze from 'deep-freeze-strict';
+
+interface State {
+  [key: string]: string;
+}
+
+describe('createMap', () => {
+  describe('add', () => {
+    it('should add items to map', () => {
+      const name = 'test';
+      const { reducer, actions } = createMap<State>({ name });
+      const test = {
+        1: 'one',
+        2: 'two',
+      };
+      const state = deepFreeze({ 3: 'three' });
+      const actual = reducer(state, actions.add(test));
+      expect(actual).toEqual({ ...state, ...test });
+    });
+  });
+
+  describe('set', () => {
+    it('should set items to map', () => {
+      const name = 'test';
+      const { reducer, actions } = createMap({ name });
+      const test = {
+        1: 'one',
+        2: 'two',
+      };
+      const state = deepFreeze({ 3: 'three' });
+      const actual = reducer(state, actions.set(test));
+      expect(actual).toEqual(test);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove items from map', () => {
+      const name = 'test';
+      const { reducer, actions } = createMap({ name });
+      const state = deepFreeze({ 1: 'one', 2: 'two', 3: 'three' });
+      const actual = reducer(state, actions.remove(['1', '2']));
+      expect(actual).toEqual({ 3: 'three' });
+    });
+  });
+
+  describe('reset', () => {
+    it('should reset map', () => {
+      const name = 'test';
+      const { reducer, actions } = createMap({ name });
+      const state = deepFreeze({ 1: 'one', 2: 'two', 3: 'three' });
+      const actual = reducer(state, actions.reset());
+      expect(actual).toEqual({});
+    });
+  });
+
+  describe('patch', () => {
+    describe('when entity is an object', () => {
+      it('should update a prop', () => {
+        interface State {
+          [key: string]: { name: string; email?: string };
+        }
+
+        const name = 'test';
+        const { reducer, actions } = createMap<State>({
+          name,
+        });
+        const state = deepFreeze({
+          1: { name: 'one' },
+          2: { name: 'two' },
+          3: { name: 'three' },
+        });
+        const actual = reducer(
+          state,
+          actions.patch({ 2: { email: 'two@wild.com' } }),
+        );
+        expect(actual).toEqual({
+          1: { name: 'one' },
+          2: { name: 'two', email: 'two@wild.com' },
+          3: { name: 'three' },
+        });
+      });
+    });
+  });
+
+  describe('when entity is *not* an object', () => {
+    it('should update a prop', () => {
+      const name = 'test';
+      const { reducer, actions } = createMap<State>({
+        name,
+      });
+      const state = deepFreeze({
+        1: 'one',
+        2: 'two',
+        3: 'three',
+      });
+      const actual = reducer(state, actions.patch({ 2: 'cool' }));
+      expect(actual).toEqual({ '1': 'one', '2': 'two', '3': 'three' });
+    });
+  });
+});

--- a/src/create-map.ts
+++ b/src/create-map.ts
@@ -1,0 +1,122 @@
+import createSlice from './create-slice';
+import { AnyState, PatchEntity, SliceHelper } from './types';
+
+export interface MapReducers<State extends AnyState = AnyState> {
+  add: (state: State, payload: State) => State;
+  set: (state: State, payload: State) => State;
+  remove: (state: State, payload: string[]) => State;
+  reset: (state: State) => State;
+  merge: (state: State, payload: PatchEntity<State>) => State;
+  patch: (state: State, payload: PatchEntity<State>) => State;
+}
+
+export function mapReducers<State extends AnyState>(
+  initialState = {} as State,
+): MapReducers<State> {
+  return {
+    add: (state: State, payload: State) => {
+      const newState = { ...state };
+      Object.keys(payload).forEach((key) => {
+        newState[key as keyof State] = payload[key];
+      });
+      return newState;
+    },
+    set: (state: State, payload: State) => payload,
+    remove: (state: State, payload: string[]) => {
+      const newState = { ...state };
+      payload.forEach((key) => {
+        delete newState[key];
+      });
+      return newState;
+    },
+    reset: (state: State) => initialState,
+    patch: (
+      state: State,
+      payload: { [key: string]: Partial<State[keyof State]> },
+    ): State => {
+      const newState = { ...state };
+      Object.keys(payload).forEach((id) => {
+        if (typeof payload[id] !== 'object') {
+          return;
+        }
+
+        const entity = payload[id];
+        if (entity) {
+          // getting weird issue with typing here
+          const s: any = newState;
+          const nextEntity = { ...s[id] };
+          Object.keys(entity).forEach((key) => {
+            if (s.hasOwnProperty(id)) {
+              nextEntity[key] = (payload[id] as any)[key];
+            }
+          });
+          (newState as any)[id] = nextEntity;
+        }
+      });
+
+      return newState;
+    },
+    merge: (
+      state: State,
+      payload: { [key: string]: Partial<State[keyof State]> },
+    ): State => {
+      const newState = { ...state };
+      Object.keys(payload).forEach((id) => {
+        if (typeof payload[id] !== 'object') {
+          return;
+        }
+
+        const entity = payload[id];
+        if (entity) {
+          // getting weird issue with typing here
+          const s: any = newState;
+          if (!s.hasOwnProperty(id)) {
+            return;
+          }
+
+          const nextEntity = { ...s[id] };
+          Object.keys(entity).forEach((key) => {
+            const prop = (payload[id] as any)[key];
+            if (Array.isArray(nextEntity[key])) {
+              nextEntity[key] = [...nextEntity[key], ...prop];
+            } else if (Object == prop.constructor) {
+              nextEntity[key] = {
+                ...nextEntity[key],
+                ...prop,
+              };
+            } else {
+              nextEntity[key] = prop;
+            }
+          });
+          (newState as any)[id] = nextEntity;
+        }
+      });
+
+      return newState;
+    },
+  };
+}
+
+interface MapActions<S> {
+  add: S;
+  set: S;
+  remove: string[];
+  patch: PatchEntity<S>;
+  reset: never;
+}
+
+export default function createMap<State extends AnyState>({
+  name,
+  extraReducers,
+  initialState = {} as State,
+}: SliceHelper<State>) {
+  const slice = createSlice<State, MapActions<State>>({
+    name,
+    initialState,
+    extraReducers,
+    useImmer: false,
+    reducers: mapReducers(initialState),
+  });
+
+  return slice;
+}

--- a/src/create-reducer.test.ts
+++ b/src/create-reducer.test.ts
@@ -17,12 +17,9 @@ describe('createReducer', () => {
       todo.completed = !todo.completed;
     }
 
-    const todosReducer = createReducer({
-      initialState: [],
-      reducers: {
-        ADD_TODO: addTodo,
-        TOGGLE_TODO: toggleTodo,
-      },
+    const todosReducer = createReducer([], {
+      ADD_TODO: addTodo,
+      TOGGLE_TODO: toggleTodo,
     });
 
     behavesLikeReducer(todosReducer);
@@ -46,12 +43,9 @@ describe('createReducer', () => {
       });
     }
 
-    const todosReducer = createReducer({
-      initialState: [],
-      reducers: {
-        ADD_TODO: addTodo,
-        TOGGLE_TODO: toggleTodo,
-      },
+    const todosReducer = createReducer([], {
+      ADD_TODO: addTodo,
+      TOGGLE_TODO: toggleTodo,
     });
 
     behavesLikeReducer(todosReducer);

--- a/src/create-reducer.ts
+++ b/src/create-reducer.ts
@@ -7,17 +7,14 @@ import { Reducer } from 'redux';
 export type CreateReducer<State = any> = {
   initialState: State;
   reducers: ReducerMap<State, any>;
-  name?: string;
   useImmer?: boolean;
 };
 
-export default function createReducer<State = any>({
-  initialState,
-  reducers,
-  name = '',
-  useImmer = true,
-}: CreateReducer<State>): Reducer<State, Action<any>> {
-  const reducerPlain = (state = initialState, action: Action<any>) => {
+export function createReducerPlain<State = any>(
+  initialState: State,
+  reducers: ReducerMap<State>,
+): Reducer<State, Action<any>> {
+  const reducer = (state = initialState, action: Action<any>) => {
     const caseReducer = reducers[action.type];
     if (!caseReducer) {
       return state;
@@ -25,7 +22,14 @@ export default function createReducer<State = any>({
     return caseReducer(state, action.payload) as State;
   };
 
-  const reducerImmer = (state = initialState, action: Action<any>) => {
+  return reducer;
+}
+
+export default function createReducer<State = any>(
+  initialState: State,
+  reducers: ReducerMap<State>,
+): Reducer<State, Action<any>> {
+  const reducer = (state = initialState, action: Action<any>) => {
     return createNextState<State>(state, (draft) => {
       const caseReducer = reducers[action.type];
       if (!caseReducer) {
@@ -35,7 +39,5 @@ export default function createReducer<State = any>({
     });
   };
 
-  const reducer = useImmer ? reducerImmer : reducerPlain;
-  reducer.toString = () => name;
   return reducer;
 }

--- a/src/create-slice.test.ts
+++ b/src/create-slice.test.ts
@@ -3,7 +3,7 @@ import createSlice from './create-slice';
 describe('createSlice', () => {
   describe('when passing slice', () => {
     const { actions, reducer } = createSlice({
-      reducts: {
+      reducers: {
         increment: (state) => state + 1,
         multiply: (state, payload: number) => state * payload,
       },
@@ -41,7 +41,7 @@ describe('createSlice', () => {
 
   describe('when mutating state object', () => {
     const { actions, reducer } = createSlice({
-      reducts: {
+      reducers: {
         setUserName: (state, payload: string) => {
           state.user = payload;
         },
@@ -60,7 +60,7 @@ describe('createSlice', () => {
   describe('when adding extra reducers', () => {
     it('should create action reducer pair without action type namespacing', () => {
       const { reducer } = createSlice({
-        reducts: {
+        reducers: {
           setUserName: (state, payload: string) => {
             state.user = payload;
           },
@@ -91,7 +91,7 @@ describe('createSlice', () => {
       createSlice({
         name: '',
         initialState: '',
-        reducts: {
+        reducers: {
           add: (state) => state,
         },
       }),

--- a/src/create-table.test.ts
+++ b/src/create-table.test.ts
@@ -1,20 +1,31 @@
-import createTable from './create-table';
+import createTable, { mustSelectEntity, tableSelectors } from './create-table';
 import deepFreeze from 'deep-freeze-strict';
 
-interface State {
-  [key: string]: string;
+interface Obj {
+  id: string;
+  text: string;
 }
+
+const defaultObj = (o: Partial<Obj> = {}): Obj => ({
+  id: '',
+  text: '',
+  ...o,
+});
+
+const ex1 = defaultObj({ id: '1', text: 'hi' });
+const ex2 = defaultObj({ id: '2', text: 'mom' });
+const ex3 = defaultObj({ id: '3', text: 'wow' });
 
 describe('createTable', () => {
   describe('add', () => {
     it('should add items to map', () => {
       const name = 'test';
-      const { reducer, actions } = createTable<State>({ name });
+      const { reducer, actions } = createTable<Obj>({ name });
       const test = {
-        1: 'one',
-        2: 'two',
+        1: ex1,
+        2: ex2,
       };
-      const state = deepFreeze({ 3: 'three' });
+      const state = deepFreeze({ 3: ex3 });
       const actual = reducer(state, actions.add(test));
       expect(actual).toEqual({ ...state, ...test });
     });
@@ -25,10 +36,10 @@ describe('createTable', () => {
       const name = 'test';
       const { reducer, actions } = createTable({ name });
       const test = {
-        1: 'one',
-        2: 'two',
+        1: ex1,
+        2: ex2,
       };
-      const state = deepFreeze({ 3: 'three' });
+      const state = deepFreeze({ 3: ex3 });
       const actual = reducer(state, actions.set(test));
       expect(actual).toEqual(test);
     });
@@ -38,9 +49,9 @@ describe('createTable', () => {
     it('should remove items from map', () => {
       const name = 'test';
       const { reducer, actions } = createTable({ name });
-      const state = deepFreeze({ 1: 'one', 2: 'two', 3: 'three' });
+      const state = deepFreeze({ 1: ex1, 2: ex2, 3: ex3 });
       const actual = reducer(state, actions.remove(['1', '2']));
-      expect(actual).toEqual({ 3: 'three' });
+      expect(actual).toEqual({ 3: ex3 });
     });
   });
 
@@ -48,37 +59,91 @@ describe('createTable', () => {
     it('should reset map', () => {
       const name = 'test';
       const { reducer, actions } = createTable({ name });
-      const state = deepFreeze({ 1: 'one', 2: 'two', 3: 'three' });
+      const state = deepFreeze({ 1: ex1, 2: ex2, 3: ex3 });
       const actual = reducer(state, actions.reset());
       expect(actual).toEqual({});
     });
   });
 
   describe('patch', () => {
-    describe('when entity is an object', () => {
-      it('should update a prop', () => {
-        interface State {
-          [key: string]: { name: string; email?: string };
-        }
+    it('should update a prop', () => {
+      interface Entity {
+        name: string;
+        email?: string;
+      }
 
-        const name = 'test';
-        const { reducer, actions } = createTable<State>({
-          name,
-        });
-        const state = deepFreeze({
-          1: { name: 'one' },
-          2: { name: 'two' },
-          3: { name: 'three' },
-        });
-        const actual = reducer(
-          state,
-          actions.patch({ 2: { email: 'two@wild.com' } }),
-        );
-        expect(actual).toEqual({
-          1: { name: 'one' },
-          2: { name: 'two', email: 'two@wild.com' },
-          3: { name: 'three' },
-        });
+      const name = 'test';
+      const { reducer, actions } = createTable<Entity>({
+        name,
+      });
+      const state = deepFreeze({
+        1: { name: 'one', email: 'one@wild.com' },
+        2: { name: 'two' },
+        3: { name: 'three', email: 'three@wild.com' },
+      });
+      const actual = reducer(
+        state,
+        actions.patch({ 2: { email: 'two@wild.com' } }),
+      );
+      expect(actual).toEqual({
+        1: { name: 'one', email: 'one@wild.com' },
+        2: { name: 'two', email: 'two@wild.com' },
+        3: { name: 'three', email: 'three@wild.com' },
+      });
+    });
+  });
+
+  describe('merge', () => {
+    it('should merge arrays', () => {
+      interface Entity {
+        name: string;
+        ids?: string[];
+      }
+      const name = 'test';
+      const { reducer, actions } = createTable<Entity>({
+        name,
+      });
+      const state = deepFreeze({
+        1: { name: 'one', ids: ['1', '2'] },
+        2: { name: 'two' },
+        3: { name: 'three', ids: ['b'] },
+      });
+      const actual = reducer(
+        state,
+        actions.merge({ 1: { ids: ['3', '4'] }, 2: { ids: ['a'] } }),
+      );
+      expect(actual).toEqual({
+        1: { name: 'one', ids: ['1', '2', '3', '4'] },
+        2: { name: 'two', ids: ['a'] },
+        3: { name: 'three', ids: ['b'] },
+      });
+    });
+
+    it('should merge objects 1-level deep', () => {
+      interface Entity {
+        name: string;
+        social?: { twitter?: string; instagram?: string };
+      }
+      const name = 'test';
+      const { reducer, actions } = createTable<Entity>({
+        name,
+      });
+      const state = deepFreeze({
+        1: { name: 'one', social: { twitter: 'abc' } },
+        2: { name: 'two' },
+        3: { name: 'three' },
+      });
+      const actual = reducer(
+        state,
+        actions.merge({
+          1: { social: { instagram: 'bbb' } },
+          2: { social: { twitter: 'xxx' } },
+        }),
+      );
+      expect(actual).toEqual({
+        1: { name: 'one', social: { twitter: 'abc', instagram: 'bbb' } },
+        2: { name: 'two', social: { twitter: 'xxx' } },
+        3: { name: 'three' },
       });
     });
   });
@@ -86,16 +151,126 @@ describe('createTable', () => {
   describe('when entity is *not* an object', () => {
     it('should update a prop', () => {
       const name = 'test';
-      const { reducer, actions } = createTable<State>({
+      const { reducer, actions } = createTable<Obj>({
         name,
       });
       const state = deepFreeze({
-        1: 'one',
-        2: 'two',
-        3: 'three',
+        1: ex1,
+        2: ex2,
+        3: ex3,
       });
-      const actual = reducer(state, actions.patch({ 2: 'cool' }));
-      expect(actual).toEqual({ '1': 'one', '2': 'two', '3': 'three' });
+      const actual = reducer(state, actions.patch({ 2: { text: 'cool' } }));
+      expect(actual).toEqual({
+        '1': ex1,
+        '2': { id: '2', text: 'cool' },
+        '3': ex3,
+      });
+    });
+  });
+});
+
+describe('createTableSelectors', () => {
+  describe('selectTableAsList selector', () => {
+    it('should return the table data as a list', () => {
+      const state = {
+        1: ex1,
+        2: ex2,
+      };
+      const selectors = tableSelectors<Obj>(() => state);
+      expect(selectors.selectTableAsList(state)).toEqual(Object.values(state));
+    });
+  });
+
+  describe('selectById selector', () => {
+    it('should return a single record in the table', () => {
+      const state = {
+        1: ex1,
+        2: ex2,
+      };
+      const selectors = tableSelectors<Obj>(() => state);
+      expect(selectors.selectById(state, { id: '1' })).toEqual(state['1']);
+    });
+
+    describe('when no record is found', () => {
+      it('should return undefined', () => {
+        const state = {
+          1: ex1,
+          2: ex2,
+        };
+        const selectors = tableSelectors<Obj>(() => state);
+        expect(selectors.selectById(state, { id: '3' })).toEqual(undefined);
+      });
+    });
+  });
+
+  describe('mustSelectById selector', () => {
+    it('should return a single record in the table', () => {
+      const state = {
+        1: ex1,
+        2: ex2,
+      };
+      const selectors = tableSelectors<Obj>(() => state);
+      const selectById = mustSelectEntity(defaultObj())(selectors.selectById);
+      expect(selectById(state, { id: '1' })).toEqual(state['1']);
+    });
+
+    describe('when no record is found', () => {
+      const state = {
+        1: ex1,
+        2: ex2,
+      };
+      const selectors = tableSelectors<Obj>(() => state);
+      const selectById = mustSelectEntity(defaultObj())(selectors.selectById);
+      expect(selectById(state, { id: '3' })).toEqual(defaultObj());
+    });
+  });
+
+  describe('selectByIds selector', () => {
+    it('should return all ids that match the params', () => {
+      const state = {
+        1: ex1,
+        2: ex2,
+        3: ex3,
+      };
+      const selectors = tableSelectors<Obj>(() => state);
+      expect(selectors.selectByIds(state, { ids: ['1', '3', '5'] })).toEqual([
+        state['1'],
+        state['3'],
+      ]);
+    });
+
+    describe('when no records were found', () => {
+      it('should return an empty array', () => {
+        const state = {
+          1: ex1,
+        };
+        const selectors = tableSelectors<Obj>(() => state);
+        expect(selectors.selectByIds(state, { ids: ['3', '5'] })).toEqual([]);
+      });
+    });
+  });
+
+  describe('mustSelectById', () => {
+    describe('when no record is found by id', () => {
+      it('should return the default entity', () => {
+        const state = {
+          1: ex1,
+        };
+        const selectors = tableSelectors<Obj>(() => state);
+        const selectById = mustSelectEntity(defaultObj)(selectors.selectById);
+        expect(selectById(state, { id: '2' })).toEqual(defaultObj());
+      });
+
+      it('should return the same variable in memory', () => {
+        const state = {
+          1: ex1,
+        };
+        const selectors = tableSelectors<Obj>(() => state);
+        const obj = defaultObj();
+        const selectById = mustSelectEntity(obj)(selectors.selectById);
+        const actual = selectById(state, { id: '2' });
+        expect(actual == obj).toBe(true);
+      });
     });
   });
 });

--- a/src/create-table.ts
+++ b/src/create-table.ts
@@ -1,70 +1,133 @@
+import { createSelector } from 'reselect';
+import { mapReducers } from './create-map';
 import createSlice from './create-slice';
-import { AnyState, PatchEntity, SliceHelper } from './types';
+import {
+  AnyState,
+  excludesFalse,
+  MapEntity,
+  PatchEntity,
+  SliceHelper,
+  PropId,
+  PropIds,
+} from './types';
 
-export function tableReducers<State extends AnyState>(
-  initialState = {} as State,
-) {
+export interface TableSelectors<Entity extends AnyState = AnyState, S = any> {
+  findById: (d: MapEntity<Entity>, { id }: PropId) => Entity | undefined;
+  findByIds: (d: MapEntity<Entity>, { ids }: PropIds) => Entity[];
+  tableAsList: (d: MapEntity<Entity>) => Entity[];
+  selectTable: (s: S) => MapEntity<Entity>;
+  selectTableAsList: (state: S) => Entity[];
+  selectById: (s: S, p: PropId) => Entity | undefined;
+  selectByIds: (s: S, p: { ids: string[] }) => Entity[];
+}
+
+export function tableSelectors<Entity extends AnyState = AnyState, S = any>(
+  selectTable: (s: S) => MapEntity<Entity>,
+): TableSelectors<Entity, S> {
+  const tableAsList = (data: MapEntity<Entity>): Entity[] =>
+    Object.values(data).filter(excludesFalse);
+  const findById = (data: MapEntity<Entity>, { id }: PropId) => data[id];
+  const findByIds = (data: MapEntity<Entity>, { ids }: PropIds): Entity[] =>
+    ids.map((id) => data[id]).filter(excludesFalse);
+  const selectById = (state: S, { id }: PropId): Entity | undefined => {
+    const data = selectTable(state);
+    return findById(data, { id });
+  };
   return {
-    add: (state: State, payload: State) => {
-      const newState = { ...state };
-      Object.keys(payload).forEach((key) => {
-        newState[key as keyof State] = payload[key];
-      });
-      return newState;
-    },
-    set: (state: State, payload: State) => payload,
-    remove: (state: State, payload: string[]) => {
-      const newState = { ...state };
-      payload.forEach((key) => {
-        delete newState[key];
-      });
-      return newState;
-    },
-    reset: (state: State) => initialState,
-    patch: (
-      state: State,
-      payload: { [key: string]: Partial<State[keyof State]> },
-    ): State => {
-      const newState = { ...state };
-      Object.keys(payload).forEach((id) => {
-        if (typeof payload[id] !== 'object') {
-          return;
-        }
-
-        Object.keys(payload[id]).forEach((key) => {
-          // getting weird issue with typing here
-          const s: any = newState;
-          if (s.hasOwnProperty(id)) {
-            s[id] = { ...s[id], [key]: (payload[id] as any)[key] };
-          }
-        });
-      });
-
-      return newState;
-    },
+    findById,
+    findByIds,
+    tableAsList,
+    selectTable,
+    selectTableAsList: createSelector(
+      selectTable,
+      (data): Entity[] => tableAsList(data),
+    ),
+    selectById,
+    selectByIds: createSelector(
+      selectTable,
+      (s: S, p: PropIds) => p,
+      findByIds,
+    ),
   };
 }
 
-interface MapActions<S> {
-  add: S;
-  set: S;
+export function mustSelectEntity<Entity extends AnyState = AnyState, S = any>(
+  defaultEntity: Entity | (() => Entity),
+) {
+  const isFn = typeof defaultEntity === 'function';
+  return (selectById: (s: S, p: PropId) => Entity | undefined) => (
+    state: S,
+    { id }: PropId,
+  ): Entity => {
+    if (isFn) {
+      const entity = defaultEntity as () => Entity;
+      return selectById(state, { id }) || entity();
+    }
+
+    return selectById(state, { id }) || (defaultEntity as Entity);
+  };
+}
+
+interface TableReducers<Entity extends AnyState = AnyState> {
+  add: (
+    state: MapEntity<Entity>,
+    payload: MapEntity<Entity>,
+  ) => MapEntity<Entity>;
+  set: (
+    state: MapEntity<Entity>,
+    payload: MapEntity<Entity>,
+  ) => MapEntity<Entity>;
+  remove: (state: MapEntity<Entity>, payload: string[]) => MapEntity<Entity>;
+  reset: (state: MapEntity<Entity>) => MapEntity<Entity>;
+  merge: (
+    state: MapEntity<Entity>,
+    payload: PatchEntity<MapEntity<Entity>>,
+  ) => MapEntity<Entity>;
+  patch: (
+    state: MapEntity<Entity>,
+    payload: PatchEntity<MapEntity<Entity>>,
+  ) => MapEntity<Entity>;
+}
+
+export function tableReducers<Entity extends AnyState = AnyState>(
+  initialState = {} as MapEntity<Entity>,
+): TableReducers<Entity> {
+  return mapReducers(initialState);
+}
+
+export function createTableAdapter<Entity extends AnyState = AnyState>(
+  initialState = {} as MapEntity<Entity>,
+) {
+  const reducers = tableReducers(initialState);
+  return {
+    reducers,
+    getSelectors: <S>(stateFn: (s: S) => MapEntity<Entity>) =>
+      tableSelectors(stateFn),
+  };
+}
+
+interface TableActions<S> {
+  add: MapEntity<S>;
+  set: MapEntity<S>;
   remove: string[];
-  patch: PatchEntity<S>;
+  patch: PatchEntity<MapEntity<S>>;
+  merge: PatchEntity<MapEntity<S>>;
   reset: never;
 }
 
-export default function createTable<State extends AnyState>({
+export default function createTable<Entity extends AnyState = AnyState>({
   name,
   extraReducers,
-  initialState = {} as State,
-}: SliceHelper<State>) {
-  const slice = createSlice<State, MapActions<State>>({
+  initialState = {} as MapEntity<Entity>,
+}: SliceHelper<MapEntity<Entity>>) {
+  const { reducers, ...adapter } = createTableAdapter<Entity>(initialState);
+  const slice = createSlice<MapEntity<Entity>, TableActions<Entity>>({
     name,
     initialState,
     extraReducers,
+    reducers,
     useImmer: false,
-    reducts: tableReducers(initialState),
   });
 
-  return slice;
+  return { ...slice, ...adapter };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from './types';
 export * from './combine';
 export * from './create-assign';
 export * from './create-table';
+export * from './create-map';
 export * from './create-loader';
 export * from './create-loader-table';
 
@@ -11,19 +12,21 @@ export { default as createAction } from './create-action';
 export { default as createReducer } from './create-reducer';
 export { default as createApp } from './create-app';
 import createTable from './create-table';
+import createMap from './create-map';
 import createLoader from './create-loader';
 import createLoaderTable from './create-table';
 import createAssign from './create-assign';
 export {
   createSlice,
   createTable,
+  createMap,
   createLoader,
   createLoaderTable,
   createAssign,
 };
 
 // All of these variable names are DEPRECATED
-const mapSlice = createTable;
+const mapSlice = createMap;
 const loadingSlice = createLoader;
 const loadingMapSlice = createLoaderTable;
 const assignSlice = createAssign;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,12 @@ export interface AnyState {
   [name: string]: any;
 }
 
+export interface MapEntity<E> {
+  [key: string]: E | undefined;
+}
+
+export const excludesFalse = <T>(n?: T): n is T => Boolean(n);
+
 export interface ReducerMap<SliceState, A = Action> {
   [Action: string]: ActionReducer<SliceState, A>;
 }
@@ -45,4 +51,12 @@ export interface SliceHelperRequired<State> {
   name: string;
   initialState: State;
   extraReducers?: ActionsAny;
+}
+
+export interface PropId {
+  id: string;
+}
+
+export interface PropIds {
+  ids: string[];
 }

--- a/type-tests/combine.ts
+++ b/type-tests/combine.ts
@@ -5,7 +5,7 @@ import { createActionMap, createReducerMap } from '../src/combine';
 const counterSlice = createSlice({
   name: 'counter',
   initialState: 0,
-  reducts: {
+  reducers: {
     inc: (state) => state + 1,
     dec: (state) => state - 1,
   },
@@ -14,7 +14,7 @@ const counterSlice = createSlice({
 const createLoader = createSlice({
   name: 'loading',
   initialState: false,
-  reducts: {
+  reducers: {
     loading: (state, payload: boolean) => payload,
   },
 });

--- a/type-tests/create-map.ts
+++ b/type-tests/create-map.ts
@@ -1,0 +1,26 @@
+import createMap from '../src/create-map';
+
+// testing no params
+const one = createMap({ name: 'SLICE' });
+// $ExpectType { add: (payload?: any) => Action<any, string>; set: (payload?: any) => Action<any, string>; remove: (payload: string[]) => Action<string[], string>; patch: (payload: PatchEntity<AnyState>) => Action<...>; reset: () => Action<...>; }
+one.actions;
+// $ExpectType Reducer<AnyState, Action<any, string>>
+one.reducer;
+// $ExpectType string
+one.name;
+
+// testing with params
+interface Obj {
+  something: boolean;
+}
+interface SliceState {
+  [key: string]: Obj;
+}
+
+const two = createMap<SliceState>({ name: 'slice' });
+// $ExpectType { add: (payload: SliceState) => Action<SliceState, string>; set: (payload: SliceState) => Action<SliceState, string>; remove: (payload: string[]) => Action<string[], string>; patch: (payload: PatchEntity<...>) => Action<...>; reset: () => Action<...>; }
+two.actions;
+// $ExpectType Reducer<SliceState, Action<any, string>>
+two.reducer;
+// $ExpectType string
+two.name;

--- a/type-tests/create-table.ts
+++ b/type-tests/create-table.ts
@@ -1,26 +1,73 @@
-import createTable from '../src/create-table';
+import createTable, { mustSelectEntity } from '../src/create-table';
+import { MapEntity } from '../src/types';
 
 // testing no params
 const one = createTable({ name: 'SLICE' });
-// $ExpectType { add: (payload?: any) => Action<any, string>; set: (payload?: any) => Action<any, string>; remove: (payload: string[]) => Action<string[], string>; patch: (payload: PatchEntity<AnyState>) => Action<...>; reset: () => Action<...>; }
+// $ExpectType { add: (payload: MapEntity<AnyState>) => Action<MapEntity<AnyState>, string>; set: (payload: MapEntity<AnyState>) => Action<MapEntity<AnyState>, string>; remove: (payload: string[]) => Action<...>; patch: (payload: PatchEntity<...>) => Action<...>; merge: (payload: PatchEntity<...>) => Action<...>; reset: () => Acti...
 one.actions;
-// $ExpectType Reducer<AnyState, Action<any, string>>
+// $ExpectType Reducer<MapEntity<AnyState>, Action<any, string>>
 one.reducer;
 // $ExpectType string
 one.name;
 
 // testing with params
-interface Obj {
-  something: boolean;
-}
-interface SliceState {
-  [key: string]: Obj;
+interface Obj { 
+  id: string; 
+  text: string; 
 }
 
-const two = createTable<SliceState>({ name: 'slice' });
-// $ExpectType { add: (payload: SliceState) => Action<SliceState, string>; set: (payload: SliceState) => Action<SliceState, string>; remove: (payload: string[]) => Action<string[], string>; patch: (payload: PatchEntity<...>) => Action<...>; reset: () => Action<...>; }
-two.actions;
-// $ExpectType Reducer<SliceState, Action<any, string>>
+interface State {
+  obj: MapEntity<Obj>;
+}
+
+const state = {
+  obj: {}
+};
+
+const two = createTable<Obj>({ name: 'slice' });
+// $ExpectType (payload: MapEntity<Obj>) => Action<MapEntity<Obj>, string>
+two.actions.add;
+// $ExpectType (payload: MapEntity<Obj>) => Action<MapEntity<Obj>, string>
+two.actions.set;
+// $ExpectType (payload: string[]) => Action<string[], string>
+two.actions.remove;
+// $ExpectType () => Action<any, string>
+two.actions.reset;
+// $ExpectType (payload: PatchEntity<MapEntity<Obj>>) => Action<PatchEntity<MapEntity<Obj>>, string>
+two.actions.merge;
+// $ExpectType (payload: PatchEntity<MapEntity<Obj>>) => Action<PatchEntity<MapEntity<Obj>>, string>
+two.actions.patch;
+// $ExpectType Reducer<MapEntity<Obj>, Action<any, string>>
 two.reducer;
 // $ExpectType string
 two.name;
+const { selectById, selectByIds, selectTableAsList, selectTable } = two.getSelectors((s: State) => s.obj);
+// $ExpectType Obj | undefined
+selectById(state, { id: '1' });
+// $ExpectType Obj[]
+selectByIds(state, { ids: ['1'] });
+// $ExpectType Obj[]
+selectTableAsList(state);
+// $ExpectType MapEntity<Obj>
+selectTable(state);
+
+const defaultObj = (): Obj => {
+  return {
+    id: '',
+    text: '',
+  }
+}
+
+const three = createTable<Obj>({ name: 'obj' });
+const selectors = three.getSelectors((s: State) => s.obj);
+const createEntitySelector = mustSelectEntity(defaultObj);
+const selectObjById = createEntitySelector(selectors.selectById);
+// $ExpectType Obj
+selectObjById(state, { id: '1' });
+const findObjById = createEntitySelector(selectors.findById);
+// $ExpectType Obj
+findObjById(state.obj, { id: '1' });
+
+const selectObj2ById = mustSelectEntity(defaultObj())(selectors.selectById);
+// $ExpectType Obj
+selectObj2ById(state, { id: '1' });

--- a/type-tests/examples.ts
+++ b/type-tests/examples.ts
@@ -26,7 +26,7 @@ const defaultState = {
 const hi = 'hi';
 const { actions, reducer } = createSlice<SliceState, Actions>({
   name: hi,
-  reducts: {
+  reducers: {
     set: (state, payload) => payload,
     reset: (state) => defaultState,
   },
@@ -65,7 +65,7 @@ const initialState: ISliceState = {
 
 const auth = createSlice<ISliceState, AuthActions>({
   name: 'auth', // slice is checked to ensure it is a key in IState
-  reducts: {
+  reducers: {
     authFail: (state, payload) => {
       state.error = payload;
       state.authenticating = false;
@@ -95,7 +95,7 @@ export const {
 
 const authWithoutInterface = createSlice({
   name: 'auth',
-  reducts: {
+  reducers: {
     authFail2: (state: ISliceState, payload: Error) => {
       state.error = payload;
       state.authenticating = false;

--- a/type-tests/reducers.ts
+++ b/type-tests/reducers.ts
@@ -1,16 +1,16 @@
-import { tableReducers } from '../src/create-table';
+import { mapReducers } from '../src/create-map';
 
 interface State {
   [key: string]: number;
 }
 
 const state = {};
-const reducers = tableReducers<State>();
+const reducers = mapReducers<State>();
 // $ExpectType (state: State, payload: State) => State
 reducers.add;
 // $ExpectError Type 'string' is not assignable to type 'number'.
 reducers.add(state, { 1: 'test' });
-// $ExpectType (state: State, payload: { [key: string]: number; }) => State
+// $ExpectType (state: State, payload: PatchEntity<State>) => State
 reducers.patch;
 // $ExpectType (state: State, payload: string[]) => State
 reducers.remove;

--- a/type-tests/slice.ts
+++ b/type-tests/slice.ts
@@ -3,7 +3,7 @@ import createSlice from '../src/create-slice';
 // testing InputWithName and 2 params
 const addFour = createSlice<number, { add: number }>({
   name: 'something',
-  reducts: { add: (state, p: number) => state + p },
+  reducers: { add: (state, p: number) => state + p },
   initialState: 0,
 });
 // $ExpectType { add: (payload: number) => Action<number, string>; }
@@ -16,7 +16,7 @@ addFour.name;
 // testing InputWithName and no params
 const addFive = createSlice({
   name: 'something' as const,
-  reducts: { add: (state, p: number) => state + p },
+  reducers: { add: (state, p: number) => state + p },
   initialState: 0,
 });
 // $ExpectType { add: (payload: number) => Action<number, string>; }
@@ -30,7 +30,7 @@ addFive.name;
 let eightSlice = 'something';
 const addEight = createSlice({
   name: eightSlice,
-  reducts: { add: (state, p: number) => state + p },
+  reducers: { add: (state, p: number) => state + p },
   initialState: 0,
 });
 // $ExpectType { add: (payload: number) => Action<number, string>; }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3927,6 +3927,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
```ts
import { createSelector } from 'reselect';
import { createTable, mustSelectById } from 'robodux';

interface Obj { 
  id: string; 
  text: string; 
}

const defaultObj = (): Obj => {
  return {
    id: '',
    text: '',
  }
}

interface State {
  obj: MapEntity<Obj>;
}

const state = {
  obj: {}
};

const slice = createTable<Obj>({ name: 'obj' });
/*
export interface TableSelectors<Entity extends AnyState = AnyState, S = any> {
  findById: (d: MapEntity<Entity>, { id }: PropId) => Entity | undefined;
  findByIds: (d: MapEntity<Entity>, { ids }: PropIds) => Entity[];
  tableAsList: (d: MapEntity<Entity>) => Entity[];
  selectTable: (s: S) => MapEntity<Entity>;
  selectTableAsList: (state: S) => Entity[];
  selectById: (s: S, p: PropId) => Entity | undefined;
  selectByIds: (s: S, p: { ids: string[] }) => Entity[];
}
*/

const slice = createTable<Obj>({ name: 'obj' });
const selectors = slice.getSelectors((s: State) => s.obj);
// enforce that the *ById functions return the entity
const createEntitySelector = mustSelectEntity(defaultObj);

// select by id
const selectObjById = createEntitySelector(selectors.selectById);
selectObjById(state, { id: '1' });

// find by id - this doesn't require the entire redux state
const findObjById = createEntitySelector(selectors.findById);
findObjById(state.obj, { id: '1' });

// can also pass a function for default entity so it will already return a new entity instead of referencing the same one in memory
const selectObj2ById = mustSelectEntity(defaultObj())(selectors.selectById);
selectObj2ById(state, { id: '1' })
```