### PR TITLE
new loader table api

### DIFF
--- a/src/create-loader-table.test.ts
+++ b/src/create-loader-table.test.ts
@@ -1,4 +1,4 @@
-import createLoaderTable from './create-loader-table';
+import createLoaderTable, { defaultLoader } from './create-loader-table';
 import { defaultLoadingItem, LoadingItemState } from './create-loader';
 
 interface State {
@@ -26,9 +26,7 @@ describe('createLoaderTable', () => {
 
     expect(reducer({}, actions.loading({ id: 'default' }))).toEqual({
       default: {
-        loading: true,
-        success: false,
-        error: false,
+        status: 'loading',
         message: '',
         meta: {},
         lastRun: 123,
@@ -42,9 +40,7 @@ describe('createLoaderTable', () => {
 
     expect(reducer({}, actions.success({ id: 'default' }))).toEqual({
       default: {
-        loading: false,
-        success: true,
-        error: false,
+        status: 'success',
         message: '',
         lastRun: 0,
         meta: {},
@@ -60,9 +56,7 @@ describe('createLoaderTable', () => {
       reducer({}, actions.error({ id: 'default', message: 'foobar' })),
     ).toEqual({
       default: {
-        loading: false,
-        success: false,
-        error: true,
+        status: 'error',
         message: 'foobar',
         lastRun: 0,
         meta: {},
@@ -78,9 +72,7 @@ describe('createLoaderTable', () => {
       reducer(
         {
           default: {
-            loading: true,
-            success: true,
-            error: true,
+            status: 'error',
             message: 'a message that will be cleared',
             lastRun: 0,
             lastSuccess: 0,
@@ -101,9 +93,7 @@ describe('createLoaderTable', () => {
       reducer(
         {
           default: {
-            loading: true,
-            success: true,
-            error: true,
+            status: 'loading',
             message: 'a message that will be cleared',
             lastRun: 0,
             lastSuccess: 0,
@@ -119,7 +109,7 @@ describe('createLoaderTable', () => {
     it('should select the entire table', () => {
       const { getSelectors } = buildLoader();
       const selectors = getSelectors((state: State) => state);
-      const users = defaultLoadingItem({ success: true });
+      const users = defaultLoadingItem({ status: 'success' });
       const token = defaultLoadingItem({ message: 'wow' });
       expect(
         selectors.selectTable({
@@ -132,8 +122,8 @@ describe('createLoaderTable', () => {
     it('should select a single loader', () => {
       const { getSelectors } = buildLoader();
       const selectors = getSelectors((state: State) => state);
-      const users = defaultLoadingItem({ success: true });
-      const token = defaultLoadingItem({ message: 'wow' });
+      const users = defaultLoader(defaultLoadingItem({ status: 'success' }));
+      const token = defaultLoader(defaultLoadingItem({ message: 'wow' }));
       const result = selectors.selectById(
         {
           users,
@@ -147,8 +137,8 @@ describe('createLoaderTable', () => {
     it('should select multiple loaders', () => {
       const { getSelectors } = buildLoader();
       const selectors = getSelectors((state: State) => state);
-      const users = defaultLoadingItem({ success: true });
-      const token = defaultLoadingItem({ message: 'wow' });
+      const users = defaultLoader(defaultLoadingItem({ status: 'success' }));
+      const token = defaultLoader(defaultLoadingItem({ message: 'wow' }));
       expect(
         selectors.selectByIds(
           {

--- a/src/create-loader.test.ts
+++ b/src/create-loader.test.ts
@@ -8,10 +8,8 @@ describe('createLoader', () => {
       const name = 'loading';
       const { reducer, actions } = createLoader({ name });
       const state = freeze({
-        error: false,
+        status: 'idle' as 'idle',
         message: '',
-        loading: false,
-        success: false,
         lastRun: 0,
         meta: {},
         lastSuccess: 0,
@@ -19,10 +17,8 @@ describe('createLoader', () => {
       const actual = reducer(state, actions.loading({ timestamp: 1 }));
 
       expect(actual).toEqual({
-        loading: true,
-        error: false,
+        status: 'loading' as 'loading',
         message: '',
-        success: false,
         lastRun: 1,
         meta: {},
         lastSuccess: 0,
@@ -33,10 +29,8 @@ describe('createLoader', () => {
       const name = 'loading';
       const { reducer, actions } = createLoader({ name });
       const state = freeze({
-        error: false,
+        status: 'idle' as 'idle',
         message: '',
-        loading: false,
-        success: false,
         lastRun: 0,
         meta: {},
         lastSuccess: 0,
@@ -47,10 +41,8 @@ describe('createLoader', () => {
       );
 
       expect(actual).toEqual({
-        loading: true,
-        error: false,
+        status: 'loading' as 'loading',
         message: 'hi there',
-        success: false,
         lastRun: 2,
         meta: {},
         lastSuccess: 0,
@@ -61,10 +53,8 @@ describe('createLoader', () => {
       const name = 'loading';
       const { reducer, actions } = createLoader({ name });
       const state = freeze({
-        error: false,
+        status: 'idle' as 'idle',
         message: '',
-        loading: true,
-        success: false,
         lastRun: 0,
         meta: {},
         lastSuccess: 0,
@@ -76,10 +66,8 @@ describe('createLoader', () => {
       Date.now = actualNow;
 
       expect(actual).toEqual({
-        loading: true,
-        error: false,
+        status: 'loading' as 'loading',
         message: '',
-        success: false,
         lastSuccess: 0,
         meta: {},
         lastRun: 123,
@@ -92,10 +80,8 @@ describe('createLoader', () => {
       const name = 'loading';
       const { reducer, actions } = createLoader({ name });
       const state = freeze({
-        error: false,
+        status: 'loading' as 'loading',
         message: '',
-        loading: true,
-        success: false,
         lastRun: 0,
         meta: {},
         lastSuccess: 0,
@@ -103,10 +89,8 @@ describe('createLoader', () => {
       const actual = reducer(state, actions.success({ timestamp: 5 }));
 
       expect(actual).toEqual({
-        loading: false,
-        error: false,
+        status: 'success' as 'success',
         message: '',
-        success: true,
         lastSuccess: 5,
         meta: {},
         lastRun: 0,
@@ -117,10 +101,8 @@ describe('createLoader', () => {
       const name = 'loading';
       const { reducer, actions } = createLoader({ name });
       const state = freeze({
-        error: false,
+        status: 'loading' as 'loading',
         message: '',
-        loading: true,
-        success: false,
         lastRun: 0,
         meta: {},
         lastSuccess: 0,
@@ -131,10 +113,8 @@ describe('createLoader', () => {
       );
 
       expect(actual).toEqual({
-        loading: false,
-        error: false,
+        status: 'success' as 'success',
         message: '',
-        success: true,
         lastSuccess: 5,
         meta: { something: 'great' },
         lastRun: 0,
@@ -145,10 +125,8 @@ describe('createLoader', () => {
       const name = 'loading';
       const { reducer, actions } = createLoader({ name });
       const state = freeze({
-        error: false,
+        status: 'idle' as 'idle',
         message: '',
-        loading: true,
-        success: false,
         lastRun: 0,
         meta: {},
         lastSuccess: 0,
@@ -159,10 +137,8 @@ describe('createLoader', () => {
       );
 
       expect(actual).toEqual({
-        loading: false,
-        error: false,
+        status: 'success' as 'success',
         message: 'wow',
-        success: true,
         meta: {},
         lastSuccess: 2,
         lastRun: 0,
@@ -173,10 +149,8 @@ describe('createLoader', () => {
       const name = 'loading';
       const { reducer, actions } = createLoader({ name });
       const state = freeze({
-        error: false,
+        status: 'idle' as 'idle',
         message: '',
-        loading: true,
-        success: false,
         lastRun: 0,
         meta: {},
         lastSuccess: 0,
@@ -188,10 +162,8 @@ describe('createLoader', () => {
       Date.now = actualNow;
 
       expect(actual).toEqual({
-        loading: false,
-        error: false,
+        status: 'success' as 'success',
         message: '',
-        success: true,
         meta: {},
         lastSuccess: 123,
         lastRun: 0,
@@ -203,10 +175,8 @@ describe('createLoader', () => {
     const name = 'loading';
     const { reducer, actions } = createLoader({ name });
     const state = freeze({
-      error: false,
+      status: 'loading' as 'loading',
       message: 'cool',
-      loading: true,
-      success: false,
       lastRun: 0,
       meta: {},
       lastSuccess: 0,
@@ -214,10 +184,8 @@ describe('createLoader', () => {
     const actual = reducer(state, actions.error({ message: 'something' }));
 
     expect(actual).toEqual({
-      loading: false,
+      status: 'error' as 'error',
       message: 'something',
-      error: true,
-      success: false,
       meta: {},
       lastRun: 0,
       lastSuccess: 0,

--- a/type-tests/create-loader.ts
+++ b/type-tests/create-loader.ts
@@ -12,7 +12,7 @@ one.actions.success();
 // $ExpectType (payload?: Partial<{ message: string; timestamp: number; meta: { [key: string]: any; }; }> | undefined) => Action<Partial<{ message: string; timestamp: number; meta: { [key: string]: any; }; }>, string>
 one.actions.error;
 one.actions.error();
-// $ExpectType Reducer<LoadingItemState<string>, Action<any, string>>
+// $ExpectType Reducer<LoadingItemState, Action<any, string>>
 one.reducer;
 
 const withPayload = createLoader({ name: 'SLICE' });
@@ -21,23 +21,21 @@ withPayload.actions;
 withPayload.actions.loading({ message: 'hi' });
 withPayload.actions.success({ message: 'nice' });
 withPayload.actions.error({ message: 'hi' });
-// $ExpectType Reducer<LoadingItemState<string>, Action<any, string>>
+// $ExpectType Reducer<LoadingItemState, Action<any, string>>
 withPayload.reducer;
 
-const two = createLoader<string | Error>({
+const two = createLoader({
   name: 'SLICE',
   initialState: {
     message: '',
-    error: false,
-    success: false,
-    loading: false,
+    status: 'idle' as 'idle',
     lastRun: 0,
     lastSuccess: 0,
     meta: {},
   },
 });
 two.actions;
-two.actions.error({ message: new Error('wow') });
+two.actions.error({ message: 'wow' });
 two.actions.loading({ message: 'loading' });
-// $ExpectType Reducer<LoadingItemState<string | Error>, Action<any, string>>
+// $ExpectType Reducer<LoadingItemState, Action<any, string>>
 two.reducer;


### PR DESCRIPTION
This PR introduces a slightly new API for `createLoaderTable`.  The main change is how we handle state for the loading items.  Previously we have three separate boolean values `loading`, `success`, and `error`.  While the reducers prevented the loader from getting into impossible states (e.g. loading and success both set to true), I thought it would make more sense to have one property `status` control the state.